### PR TITLE
ci: switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +20,10 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 bundles npm 10
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Configure git
         run: |
@@ -41,5 +46,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

Every publish since May 26 has failed with `E404 Not Found - PUT https://registry.npmjs.org/rhombus-node-mcp`. That 404 is npm masking an **auth failure** — the `NPM_TOKEN` repo secret expired or was revoked (npm now caps granular tokens at 90 days and revoked classic tokens). Last successful publish was 0.1.36 on May 11; versions 0.1.37–0.1.42 were bumped but never published.

## What

Switch the publish workflow to [npm trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) — no token, nothing to expire:

- add `id-token: write` job permission
- update npm to latest (trusted publishing needs npm ≥ 11.5.1; Node 20 bundles npm 10)
- drop `NODE_AUTH_TOKEN` from the publish step

## ⚠️ Before merging

A package admin must configure the trusted publisher on npmjs.com (~2 min):
**npmjs.com → rhombus-node-mcp → Settings → Trusted Publisher → GitHub Actions**, with:
- Organization: `RhombusSystems`
- Repository: `rhombus-node-mcp`
- Workflow filename: `publish.yml`

Merging before that is configured will fail the publish step. After merge, the stale `NPM_TOKEN` secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)