### PR TITLE
feat: badge-timeline-tool (follow-the-badge) + shared media-correlation helper

### DIFF
--- a/src/api/badge-correlation.ts
+++ b/src/api/badge-correlation.ts
@@ -1,0 +1,63 @@
+/**
+ * Keystone correlation helper for the OnGuard feature set.
+ *
+ * Given a badge-event-like entry (a camera `deviceUuid` + a `timestampMs`), produce the media hints
+ * the agent needs to *show* the moment: a still (camera-tool `image`) and a short clip window
+ * (clips-tool `createClip`). Pure and reusable — the follow-the-badge timeline, anomaly review, and
+ * lost-badge tracking all turn badge events into "here's the picture/video" the same way.
+ *
+ * Kept deliberately small and side-effect-free. Richer correlation (co-located face events,
+ * people-count in the window) layers on top of this when those features land.
+ */
+
+export interface BadgeEventLike {
+  /** The camera that saw the event. Some OnGuard events aren't mapped to a camera. */
+  deviceUuid?: string;
+  /** Event time, epoch ms. */
+  timestampMs?: number;
+}
+
+export interface ClipHint {
+  /** The camera that saw the event. Pass to clips-tool `createClip`. */
+  deviceUuid: string;
+  startTimeMs: number;
+  endTimeMs: number;
+}
+
+export interface StillHint {
+  /** The camera that saw the event. Pass to camera-tool (requestType `image`). */
+  deviceUuid: string;
+  timestampMs: number;
+}
+
+export interface MediaHints {
+  clipHint?: ClipHint;
+  stillHint?: StillHint;
+}
+
+export const DEFAULT_CLIP_PADDING_SECONDS = 15;
+
+/**
+ * Build still + clip hints for a single badge event. Returns empty hints (no clip/still) when the
+ * event lacks a camera or timestamp, so callers can render those events without media gracefully.
+ */
+export function buildMediaHints(
+  event: BadgeEventLike,
+  clipPaddingSeconds: number = DEFAULT_CLIP_PADDING_SECONDS
+): MediaHints {
+  if (!event.deviceUuid || event.timestampMs == null) {
+    return {};
+  }
+  const padMs = Math.max(0, clipPaddingSeconds) * 1000;
+  return {
+    clipHint: {
+      deviceUuid: event.deviceUuid,
+      startTimeMs: event.timestampMs - padMs,
+      endTimeMs: event.timestampMs + padMs,
+    },
+    stillHint: {
+      deviceUuid: event.deviceUuid,
+      timestampMs: event.timestampMs,
+    },
+  };
+}

--- a/src/api/badge-timeline-tool-api.ts
+++ b/src/api/badge-timeline-tool-api.ts
@@ -1,0 +1,86 @@
+import { buildMediaHints } from "./badge-correlation.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import type { RequestModifiers } from "../util.js";
+
+export interface GetBadgeTimelineArgs {
+  cardholderQuery: string;
+  locationUuids?: string[];
+  afterMs?: number;
+  beforeMs?: number;
+  clipPaddingSeconds?: number;
+  limit?: number;
+}
+
+/**
+ * Reconstructs a single cardholder's movements as a chronological timeline of OnGuard badge taps,
+ * each with the still/clip hints needed to show what happened. Pure orchestration over
+ * searchOnGuardEvents + the shared correlation helper.
+ */
+export async function getBadgeTimeline(
+  args: GetBadgeTimelineArgs,
+  timeZone: string,
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+) {
+  const { events } = await searchOnGuardEvents(
+    {
+      cardholderQuery: args.cardholderQuery,
+      locationUuids: args.locationUuids,
+      afterMs: args.afterMs,
+      beforeMs: args.beforeMs,
+      limit: args.limit ?? 200,
+    },
+    timeZone,
+    requestModifiers,
+    sessionId
+  );
+
+  // searchOnGuardEvents returns newest-first; a timeline reads chronologically.
+  const ordered = events
+    .filter((e) => e.timestampMs != null)
+    .sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
+
+  const stops = ordered.map((e, i) => {
+    const next = ordered[i + 1];
+    const gapToNextSeconds =
+      next?.timestampMs != null && e.timestampMs != null
+        ? Math.round((next.timestampMs - e.timestampMs) / 1000)
+        : undefined;
+    const { clipHint, stillHint } = buildMediaHints(
+      { deviceUuid: e.deviceUuid, timestampMs: e.timestampMs },
+      args.clipPaddingSeconds
+    );
+    return {
+      timestampMs: e.timestampMs,
+      datetime: e.datetime,
+      deviceUuid: e.deviceUuid,
+      area: e.areaEntering ?? e.areaExiting,
+      label: e.label,
+      isAnomaly: e.isAnomaly,
+      clipHint,
+      stillHint,
+      gapToNextSeconds,
+    };
+  });
+
+  // The sequence of areas traversed, collapsing consecutive repeats.
+  const path: string[] = [];
+  for (const stop of stops) {
+    if (stop.area && stop.area !== path[path.length - 1]) {
+      path.push(stop.area);
+    }
+  }
+
+  // cardholderQuery is full-text, so it can match more than one person — surface that so the agent
+  // can disambiguate rather than silently merge two people's movements.
+  const distinctCardholders = [
+    ...new Set(ordered.map((e) => e.cardholderName).filter((n): n is string => !!n)),
+  ];
+
+  return {
+    cardholderName: distinctCardholders[0],
+    ambiguousCardholders: distinctCardholders.length > 1 ? distinctCardholders : undefined,
+    stops,
+    path,
+  };
+}

--- a/src/tools-console/badge-timeline-tool.ts
+++ b/src/tools-console/badge-timeline-tool.ts
@@ -1,0 +1,65 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getBadgeTimeline } from "../api/badge-timeline-tool-api.js";
+import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/badge-timeline-tool-types.js";
+import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+
+const TOOL_NAME = "badge-timeline-tool";
+
+const TOOL_DESCRIPTION = `
+Reconstructs one person's movements through a building from their Honeywell OnGuard (Lenel) badge taps.
+Use this for incident reconstruction / "follow the badge" requests, e.g. "reconstruct Eve's movements
+yesterday" or "where did this cardholder go".
+
+Returns the cardholder's badge taps in CHRONOLOGICAL order (oldest first), each with:
+- datetime / timestampMs and the area entered
+- deviceUuid: the camera at that door
+- clipHint (camera + start/end window) and stillHint (camera + timestamp)
+- gapToNextSeconds: time until the next tap (a large gap = unobserved movement between doors)
+plus a "path" array summarizing the areas traversed in order.
+
+Resolve relative times like "yesterday" to ISO 8601 first (use the timestamp tool), then pass
+startTime/endTime. cardholderQuery is a full-text name match; if "ambiguousCardholders" is returned the
+query matched more than one person — ask the user which one before trusting the timeline.
+
+IMPORTANT — to show the movement visually: for each stop (or the key transitions), call the camera-tool
+(requestType "image", cameraUuid = stop.deviceUuid, timestamp = stop.timestampMs) for a still you can see,
+and/or the clips-tool (requestType "createClip", using stop.clipHint) for video. Issue those per-stop
+media calls in PARALLEL, then present the timeline as a chronological narrative.
+`;
+
+const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
+  const { requestModifiers, sessionId } = extractFromToolExtra(_extra);
+
+  try {
+    const result = await getBadgeTimeline(
+      {
+        cardholderQuery: args.cardholderQuery,
+        locationUuids: args.locationUuids ?? undefined,
+        afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
+        beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        clipPaddingSeconds: args.clipPaddingSeconds ?? undefined,
+        limit: args.limit ?? undefined,
+      },
+      args.timeZone ?? "UTC",
+      requestModifiers,
+      sessionId
+    );
+    return createToolStructuredContent<OUTPUT_SCHEMA>(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return createToolStructuredContent<OUTPUT_SCHEMA>({ error: message });
+  }
+};
+
+export function createTool(server: McpServer) {
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description: TOOL_DESCRIPTION,
+      inputSchema: TOOL_ARGS,
+      outputSchema: OUTPUT_SCHEMA.shape,
+    },
+    TOOL_HANDLER
+  );
+}

--- a/src/types/badge-timeline-tool-types.ts
+++ b/src/types/badge-timeline-tool-types.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import { createUuidSchema } from "../types.js";
+import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
+
+export const TOOL_ARGS = {
+  cardholderQuery: z
+    .string()
+    .describe('The cardholder (person) to reconstruct, full-text name match, e.g. "Eve" or "Eve Adams".'),
+  locationUuids: z
+    .array(createUuidSchema())
+    .nullable()
+    .describe("Optional: restrict to these Rhombus location UUIDs. Use the location-tool to resolve names."),
+  startTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("Start of the window (inclusive). " + ISOTimestampFormatDescription),
+  endTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("End of the window (inclusive). " + ISOTimestampFormatDescription),
+  clipPaddingSeconds: z
+    .number()
+    .nullable()
+    .describe("Seconds of video before/after each badge tap to include in the clip hint (default 15)."),
+  limit: z.number().nullable().describe("Maximum badge taps to include (default 200)."),
+  timeZone: z
+    .string()
+    .nullable()
+    .describe("IANA timezone used to format times, e.g. America/New_York. Defaults to UTC."),
+};
+
+const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
+export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
+
+const ClipHintSchema = z
+  .object({
+    deviceUuid: z.string(),
+    startTimeMs: z.number(),
+    endTimeMs: z.number(),
+  })
+  .describe("Pass to clips-tool createClip to get video of this tap.");
+
+const StillHintSchema = z
+  .object({
+    deviceUuid: z.string(),
+    timestampMs: z.number(),
+  })
+  .describe("Pass to camera-tool (requestType image) to get a still of this tap.");
+
+export const BadgeTimelineStopSchema = z.object({
+  timestampMs: z.number().optional(),
+  datetime: z.string().optional().describe("Human-readable tap time in the requested timezone."),
+  deviceUuid: z
+    .string()
+    .optional()
+    .describe("The camera at this door. Pass to camera-tool (image) or clips-tool (createClip)."),
+  area: z.string().optional().describe("The area entered (or exited) at this tap."),
+  label: z.string().optional(),
+  isAnomaly: z.boolean().optional().describe("True if this tap was an alerting/anomalous event."),
+  clipHint: ClipHintSchema.optional(),
+  stillHint: StillHintSchema.optional(),
+  gapToNextSeconds: z
+    .number()
+    .optional()
+    .describe("Seconds until the next tap — large gaps are unobserved movement between doors."),
+});
+
+export const OUTPUT_SCHEMA = z.object({
+  cardholderName: z.string().optional().describe("The resolved cardholder name."),
+  ambiguousCardholders: z
+    .array(z.string())
+    .optional()
+    .describe("Set when the query matched more than one person — disambiguate with the user before trusting the timeline."),
+  stops: z
+    .array(BadgeTimelineStopSchema)
+    .optional()
+    .describe("The cardholder's badge taps in chronological order (oldest first)."),
+  path: z.array(z.string()).optional().describe("Areas traversed, in order (consecutive repeats collapsed)."),
+  error: z.string().optional(),
+});
+export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;


### PR DESCRIPTION
## What
First increment of the OnGuard×Rhombus security feature set (plan: `MIND_ONGUARD_FEATURES_PLAN.md`; kickoff: `HONEYWELL_MAGIC_KICKOFF.md`).

- **`src/api/badge-correlation.ts` — the keystone correlation helper.** `buildMediaHints` turns a badge event (camera `deviceUuid` + `timestampMs`) into a **still hint** (camera-tool `image`) and a **clip hint** (clips-tool `createClip`, padded window). Pure, side-effect-free, and reused by the upcoming anomaly-review / lost-badge features — "badge event → show me the picture/video" defined once.
- **`badge-timeline-tool` (Feature 3, "follow the badge").** Reconstructs one cardholder's movements as a **chronological** timeline of OnGuard badge taps — each with `clipHint`/`stillHint`, `gapToNextSeconds`, area, and anomaly flag — plus an ordered `path` of areas traversed. Surfaces `ambiguousCardholders` when the full-text name matches more than one person.

## Why
"Reconstruct Eve's movements yesterday" is the genuinely investigative (pull/MIND) feature in the set — pure orchestration over the already-shipped `searchOnGuardEvents` + camera/clips tools. It ships fast, gives an immediate visible win, and proves the shared correlation helper the rest of the features build on.

## How
- `getBadgeTimeline` calls `searchOnGuardEvents({cardholderQuery, ...})`, sorts ascending (search returns newest-first), maps each tap through `buildMediaHints`, computes the gap to the next tap, and derives the area `path` (collapsing consecutive repeats).
- Auto-registered via the `tools-console` directory scan; **deferred** by default (discovered via `tool_search`), consistent with the rest of the catalog. The tool description steers the agent to call camera-tool/clips-tool per stop **in parallel** and present a chronological narrative.

## Testing
- `npm run build` (tsc) clean.
- MCP server boots and registers it: **33 tools, `badge-timeline-tool` present**, correct input schema.
- `getBadgeTimeline` drives `searchOnGuardEvents` with the correct request body (verified against the sandbox endpoint). **Live-data validation against OnGuard events is pending a healthy sandbox** (the sandbox is currently drifted; the kickoff doc prescribes the synthetic-event E2E playbook used for the OnGuard search work).

## Next in the series
The OnGuard→PolicyAlert bridge (detection keystone) in `rhombus-cloud-kconsumer-integrations`, then F5/F1-Tier1 detection. See the kickoff doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)