### PR TITLE
feat: access-anomaly-tool (F4 — anomalous access detection)

### DIFF
--- a/src/api/access-anomaly-tool-api.ts
+++ b/src/api/access-anomaly-tool-api.ts
@@ -1,0 +1,158 @@
+import { buildMediaHints } from "./badge-correlation.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import type { RequestModifiers } from "../util.js";
+
+export interface GetAccessAnomaliesArgs {
+  area?: string;
+  locationUuids?: string[];
+  deviceUuids?: string[];
+  afterMs?: number;
+  beforeMs?: number;
+  rules?: string[];
+  baselineDays?: number;
+  offHoursStartHour?: number;
+  offHoursEndHour?: number;
+  impossibleTravelMaxSeconds?: number;
+  limit?: number;
+}
+
+type OnGuardEvent = Awaited<ReturnType<typeof searchOnGuardEvents>>["events"][number];
+
+interface Finding {
+  cardholderName?: string;
+  rule: string;
+  severity: "high" | "medium";
+  datetime?: string;
+  timestampMs?: number;
+  deviceUuid?: string;
+  area?: string;
+  rationale: string;
+  clipHint?: ReturnType<typeof buildMediaHints>["clipHint"];
+  stillHint?: ReturnType<typeof buildMediaHints>["stillHint"];
+}
+
+const ALL_RULES = [
+  "lost_or_inactive_badge",
+  "entry_not_made",
+  "off_hours",
+  "impossible_travel",
+  "area_novelty",
+];
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Flags anomalous OnGuard access events over a window: deterministic rules (lost/inactive badge, no-entry,
+ * off-hours, impossible travel, first-time-in-area vs a baseline) computed over searchOnGuardEvents, each
+ * finding carrying the still/clip hints to confirm it. The agent narrates/triages from here.
+ */
+export async function getAccessAnomalies(
+  args: GetAccessAnomaliesArgs,
+  timeZone: string,
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+) {
+  const rules = new Set(args.rules && args.rules.length ? args.rules : ALL_RULES);
+  const offStart = args.offHoursStartHour ?? 7;
+  const offEnd = args.offHoursEndHour ?? 19;
+  const maxTravelSec = args.impossibleTravelMaxSeconds ?? 30;
+  const baselineDays = args.baselineDays ?? 30;
+  const scope = { area: args.area, locationUuids: args.locationUuids, deviceUuids: args.deviceUuids };
+
+  const { events } = await searchOnGuardEvents(
+    { ...scope, afterMs: args.afterMs, beforeMs: args.beforeMs, limit: args.limit ?? 500 },
+    timeZone,
+    requestModifiers,
+    sessionId
+  );
+
+  // Baseline area-set per cardholder (for area_novelty).
+  const baselineAreas = new Map<string, Set<string>>();
+  if (rules.has("area_novelty") && baselineDays > 0 && args.afterMs != null) {
+    const { events: baseEvents } = await searchOnGuardEvents(
+      { ...scope, afterMs: args.afterMs - baselineDays * DAY_MS, beforeMs: args.afterMs, limit: 1000 },
+      timeZone,
+      requestModifiers,
+      sessionId
+    );
+    for (const e of baseEvents) {
+      if (!e.cardholderName || !e.areaEntering) continue;
+      const set = baselineAreas.get(e.cardholderName) ?? new Set<string>();
+      set.add(e.areaEntering);
+      baselineAreas.set(e.cardholderName, set);
+    }
+  }
+
+  const hourFmt = new Intl.DateTimeFormat("en-US", { timeZone, hour: "2-digit", hourCycle: "h23" });
+  const localHour = (ms: number) => parseInt(hourFmt.format(new Date(ms)), 10);
+
+  const findings: Finding[] = [];
+  const seen = new Set<string>();
+  const add = (e: OnGuardEvent, rule: string, severity: "high" | "medium", rationale: string) => {
+    const key = `${e.cardholderName ?? ""}|${rule}|${e.timestampMs ?? ""}|${e.areaEntering ?? ""}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const { clipHint, stillHint } = buildMediaHints({ deviceUuid: e.deviceUuid, timestampMs: e.timestampMs });
+    findings.push({
+      cardholderName: e.cardholderName,
+      rule,
+      severity,
+      datetime: e.datetime,
+      timestampMs: e.timestampMs,
+      deviceUuid: e.deviceUuid,
+      area: e.areaEntering ?? e.areaExiting,
+      rationale,
+      clipHint,
+      stillHint,
+    });
+  };
+
+  for (const e of events) {
+    const at = e.areaEntering ? ` at "${e.areaEntering}"` : "";
+    if (rules.has("lost_or_inactive_badge") && e.badgeStatus && e.badgeStatus.toLowerCase() !== "active") {
+      add(e, "lost_or_inactive_badge", "high", `Badge status "${e.badgeStatus}" used${at}.`);
+    }
+    if (rules.has("entry_not_made") && e.entryMade === false) {
+      add(e, "entry_not_made", "medium", `Access granted but no entry made${at} — possible tailgating or aborted entry.`);
+    }
+    if (rules.has("off_hours") && e.timestampMs != null) {
+      const h = localHour(e.timestampMs);
+      if (h < offStart || h >= offEnd) {
+        add(e, "off_hours", "medium", `Entry ${e.datetime ?? `${h}:00`} is outside business hours (${offStart}:00–${offEnd}:00)${at}.`);
+      }
+    }
+    if (rules.has("area_novelty") && baselineAreas.size > 0 && e.cardholderName && e.areaEntering) {
+      const base = baselineAreas.get(e.cardholderName);
+      if (base && !base.has(e.areaEntering)) {
+        add(e, "area_novelty", "high", `First entry to "${e.areaEntering}" — not in ${e.cardholderName}'s prior ${baselineDays}-day pattern.`);
+      }
+    }
+  }
+
+  // Impossible travel: per cardholder, consecutive taps in different areas within the window.
+  if (rules.has("impossible_travel")) {
+    const byPerson = new Map<string, OnGuardEvent[]>();
+    for (const e of events) {
+      if (!e.cardholderName || e.timestampMs == null) continue;
+      const arr = byPerson.get(e.cardholderName) ?? [];
+      arr.push(e);
+      byPerson.set(e.cardholderName, arr);
+    }
+    for (const [name, evs] of byPerson) {
+      const sorted = evs.slice().sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
+      for (let i = 1; i < sorted.length; i++) {
+        const a = sorted[i - 1];
+        const b = sorted[i];
+        const gapSec = ((b.timestampMs ?? 0) - (a.timestampMs ?? 0)) / 1000;
+        if (a.areaEntering && b.areaEntering && a.areaEntering !== b.areaEntering && gapSec <= maxTravelSec) {
+          add(b, "impossible_travel", "high", `${name} at "${a.areaEntering}" then "${b.areaEntering}" ${Math.round(gapSec)}s apart — physically implausible for one person.`);
+        }
+      }
+    }
+  }
+
+  const sev = (s: string) => (s === "high" ? 0 : 1);
+  findings.sort((a, b) => sev(a.severity) - sev(b.severity) || (b.timestampMs ?? 0) - (a.timestampMs ?? 0));
+
+  return { findings, eventsAnalyzed: events.length };
+}

--- a/src/tools-console/access-anomaly-tool.ts
+++ b/src/tools-console/access-anomaly-tool.ts
@@ -1,0 +1,68 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getAccessAnomalies } from "../api/access-anomaly-tool-api.js";
+import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/access-anomaly-tool-types.js";
+import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+
+const TOOL_NAME = "access-anomaly-tool";
+
+const TOOL_DESCRIPTION = `
+Scans Honeywell OnGuard (Lenel) access events over a time window and flags anomalous badge activity. Use for
+"find unusual badge activity", "anything suspicious in access this week", or proactive access review.
+
+Runs deterministic rules and returns ranked findings (high severity first):
+- lost_or_inactive_badge: a non-active badge (lost/suspended) was used
+- entry_not_made: access granted but no entry made (possible tailgating)
+- off_hours: entry outside business hours (configurable)
+- impossible_travel: one cardholder at two different areas seconds apart
+- area_novelty: a cardholder's first-ever entry to an area vs their prior history (needs a baseline window)
+
+Each finding includes cardholderName, the rule, severity, datetime, area, the camera deviceUuid, a plain-language
+rationale, and clip/still hints. Resolve relative times (e.g. "this week") to ISO 8601 first via the timestamp tool.
+
+This is a triage aid: present findings grouped by severity, and for the notable ones call the camera-tool
+(requestType "image", cameraUuid = finding.deviceUuid, timestamp = finding.timestampMs) and/or clips-tool
+("createClip" using finding.clipHint) — in PARALLEL — so a human can confirm. Don't assert wrongdoing; surface the
+evidence.
+`;
+
+const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
+  const { requestModifiers, sessionId } = extractFromToolExtra(_extra);
+
+  try {
+    const result = await getAccessAnomalies(
+      {
+        area: args.area ?? undefined,
+        locationUuids: args.locationUuids ?? undefined,
+        deviceUuids: args.deviceUuids ?? undefined,
+        afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
+        beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        rules: args.rules ?? undefined,
+        baselineDays: args.baselineDays ?? undefined,
+        offHoursStartHour: args.offHoursStartHour ?? undefined,
+        offHoursEndHour: args.offHoursEndHour ?? undefined,
+        impossibleTravelMaxSeconds: args.impossibleTravelMaxSeconds ?? undefined,
+        limit: args.limit ?? undefined,
+      },
+      args.timeZone ?? "UTC",
+      requestModifiers,
+      sessionId
+    );
+    return createToolStructuredContent<OUTPUT_SCHEMA>(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return createToolStructuredContent<OUTPUT_SCHEMA>({ error: message });
+  }
+};
+
+export function createTool(server: McpServer) {
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description: TOOL_DESCRIPTION,
+      inputSchema: TOOL_ARGS,
+      outputSchema: OUTPUT_SCHEMA.shape,
+    },
+    TOOL_HANDLER
+  );
+}

--- a/src/types/access-anomaly-tool-types.ts
+++ b/src/types/access-anomaly-tool-types.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+import { createUuidSchema } from "../types.js";
+import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
+
+export const ANOMALY_RULES = [
+  "lost_or_inactive_badge",
+  "entry_not_made",
+  "off_hours",
+  "impossible_travel",
+  "area_novelty",
+] as const;
+
+export const TOOL_ARGS = {
+  area: z.string().nullable().describe("Optional: restrict analysis to events entering this area (full-text)."),
+  locationUuids: z
+    .array(createUuidSchema())
+    .nullable()
+    .describe("Optional: restrict to these Rhombus location UUIDs."),
+  deviceUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these camera UUIDs."),
+  startTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("Start of the window to analyze (inclusive). " + ISOTimestampFormatDescription),
+  endTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("End of the window to analyze (inclusive). " + ISOTimestampFormatDescription),
+  rules: z
+    .array(z.enum(ANOMALY_RULES))
+    .nullable()
+    .describe(
+      "Which rules to run; default all. Options: lost_or_inactive_badge, entry_not_made, off_hours, impossible_travel, area_novelty."
+    ),
+  baselineDays: z
+    .number()
+    .nullable()
+    .describe("Days of prior history used to learn each person's normal areas for area_novelty (default 30; 0 disables it)."),
+  offHoursStartHour: z
+    .number()
+    .nullable()
+    .describe("Local business-hours start hour 0–23; entries before it are off-hours (default 7)."),
+  offHoursEndHour: z
+    .number()
+    .nullable()
+    .describe("Local business-hours end hour 0–23; entries at/after it are off-hours (default 19)."),
+  impossibleTravelMaxSeconds: z
+    .number()
+    .nullable()
+    .describe("Max seconds between two different-area taps by one person to flag impossible travel (default 30)."),
+  limit: z.number().nullable().describe("Max events to analyze in the window (default 500)."),
+  timeZone: z
+    .string()
+    .nullable()
+    .describe("IANA timezone for hour-of-day checks and formatting, e.g. America/New_York. Defaults to UTC."),
+};
+
+const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
+export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
+
+const ClipHintSchema = z.object({ deviceUuid: z.string(), startTimeMs: z.number(), endTimeMs: z.number() });
+const StillHintSchema = z.object({ deviceUuid: z.string(), timestampMs: z.number() });
+
+export const AnomalyFindingSchema = z.object({
+  cardholderName: z.string().optional(),
+  rule: z.string().describe("Which rule fired."),
+  severity: z.string().describe('"high" or "medium".'),
+  datetime: z.string().optional(),
+  timestampMs: z.number().optional(),
+  deviceUuid: z.string().optional().describe("Camera at the event. Pass to camera-tool (image) / clips-tool (createClip)."),
+  area: z.string().optional(),
+  rationale: z.string().describe("Plain-language explanation of why this was flagged."),
+  clipHint: ClipHintSchema.optional(),
+  stillHint: StillHintSchema.optional(),
+});
+
+export const OUTPUT_SCHEMA = z.object({
+  findings: z
+    .array(AnomalyFindingSchema)
+    .optional()
+    .describe("Anomalies, ranked high severity first then most-recent."),
+  eventsAnalyzed: z.number().optional(),
+  error: z.string().optional(),
+});
+export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;


### PR DESCRIPTION
## What
Adds **`access-anomaly-tool`** (Feature 4) — a MIND tool that scans LenelS2 access events (OnGuard · NetBox · Elements) over a window and flags anomalous badge activity.

## Rules (deterministic, ranked high→medium)
- `lost_or_inactive_badge` — a non-active badge used (high)
- `entry_not_made` — access granted, no entry / possible tailgating (medium)
- `off_hours` — entry outside configurable business hours (medium)
- `impossible_travel` — one cardholder at two different areas seconds apart (high)
- `area_novelty` — first-ever entry to an area vs the person's prior baseline window (high)

Each finding: cardholder, rule, severity, datetime, area, camera `deviceUuid`, a plain-language rationale, and clip/still hints (via the shared `badge-correlation` helper). The tool description steers the agent to pull the camera image/clip per notable finding **in parallel** and present as triage — surfacing evidence, not asserting wrongdoing.

## How
Pure orchestration over `searchOnGuardEvents` (one window pull + an optional baseline pull for `area_novelty`). No new backend.

## Notes
- **Stacked on PR #30** (`badge-timeline-tool`) for the shared `badge-correlation` helper; will retarget to `main` once #30 merges.
- `tsc` clean; MCP server registers it (34 tools). **Kept open for sandbox validation before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)