### PR TITLE
feat: lost-badge-tool (F5 Tier A — lost/stolen-badge live response)

### DIFF
--- a/src/api/faces-tool-api.ts
+++ b/src/api/faces-tool-api.ts
@@ -143,8 +143,10 @@ export async function searchSimilarFaces(
 	if (res.error) throw new Error(JSON.stringify(res));
 	return (res.faceEvents || []).map((event: any) => ({
 		uuid: event.uuid ?? undefined,
+		deviceUuid: event.deviceUuid ?? undefined,
 		personUuid: event.personUuid ?? undefined,
 		similarity: event.similarity ?? undefined,
+		eventTimestampMs: event.eventTimestamp ?? undefined,
 		eventTimestamp: event.eventTimestamp
 			? formatTimestamp(event.eventTimestamp, timeZone)
 			: undefined,

--- a/src/api/lost-badge-tool-api.ts
+++ b/src/api/lost-badge-tool-api.ts
@@ -1,0 +1,145 @@
+import { buildMediaHints, type ClipHint, type StillHint } from "./badge-correlation.js";
+import { getFaceEvents, searchSimilarFaces } from "./faces-tool-api.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import type { RequestModifiers } from "../util.js";
+
+export interface GetLostBadgeResponseArgs {
+  area?: string;
+  locationUuids?: string[];
+  deviceUuids?: string[];
+  afterMs?: number;
+  beforeMs?: number;
+  faceWindowSeconds?: number;
+  limit?: number;
+}
+
+interface FaceAtDoor {
+  faceName?: string;
+  personUuid?: string;
+  thumbnailS3Key?: string;
+  faceEventUuid?: string;
+  eventTimestamp?: string;
+}
+interface Sighting {
+  deviceUuid?: string;
+  datetime?: string;
+  timestampMs?: number;
+  similarity?: number;
+  personUuid?: string;
+}
+interface LostBadgeIncident {
+  cardholderOfRecord?: string;
+  badgeStatus?: string;
+  datetime?: string;
+  timestampMs?: number;
+  deviceUuid?: string;
+  area?: string;
+  clipHint?: ClipHint;
+  stillHint?: StillHint;
+  facesAtDoor: FaceAtDoor[];
+  sightings: Sighting[];
+  lastKnownSighting?: { deviceUuid?: string; datetime?: string };
+}
+
+/**
+ * Lost / stolen-badge live response. Finds recent lost/inactive-badge use, and for each: the door clip/still,
+ * the face captured at the door (identified or UNIDENTIFIED), and a cross-camera track of that same face
+ * (via similar-face search) ordered to a last-known location. Detection + door evidence are exact; the track
+ * is best-effort (depends on face capture + recognition coverage).
+ */
+export async function getLostBadgeResponse(
+  args: GetLostBadgeResponseArgs,
+  timeZone: string,
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+): Promise<{ incidents: LostBadgeIncident[]; count: number }> {
+  const scope = { area: args.area, locationUuids: args.locationUuids, deviceUuids: args.deviceUuids };
+  const { events } = await searchOnGuardEvents(
+    { ...scope, anomalyOnly: true, afterMs: args.afterMs, beforeMs: args.beforeMs, limit: args.limit ?? 50 },
+    timeZone,
+    requestModifiers,
+    sessionId
+  );
+
+  // anomalyOnly returns lost-badge AND no-entry anomalies; keep the lost/inactive-badge ones.
+  const lostEvents = events.filter((e) => e.badgeStatus && e.badgeStatus.toLowerCase() !== "active");
+  const winMs = (args.faceWindowSeconds ?? 30) * 1000;
+
+  const incidents: LostBadgeIncident[] = [];
+  for (const e of lostEvents) {
+    const { clipHint, stillHint } = buildMediaHints({ deviceUuid: e.deviceUuid, timestampMs: e.timestampMs });
+    let facesAtDoor: FaceAtDoor[] = [];
+    let sightings: Sighting[] = [];
+
+    if (e.deviceUuid && e.timestampMs != null) {
+      try {
+        // Face(s) at the door: query by time window (the faces tool can't filter by device), then match
+        // the door camera client-side.
+        const { faceEvents } = await getFaceEvents(
+          {
+            pageRequest: { lastEvaluatedKey: null, maxPageSize: 75 },
+            searchFilter: {
+              faceNameContains: null,
+              faceNames: [],
+              hasEmbedding: null,
+              hasName: null,
+              labels: [],
+              locationUuids: [],
+              personUuids: [],
+              timestampFilter: {
+                rangeStart: new Date(e.timestampMs - winMs).toISOString(),
+                rangeEnd: new Date(e.timestampMs + winMs).toISOString(),
+              },
+            },
+          },
+          timeZone,
+          requestModifiers,
+          sessionId
+        );
+        facesAtDoor = faceEvents
+          .filter((f) => f.deviceUuid === e.deviceUuid)
+          .map((f) => ({
+            faceName: f.faceName ?? undefined,
+            personUuid: f.personUuid ?? undefined,
+            thumbnailS3Key: f.thumbnailS3Key ?? undefined,
+            faceEventUuid: f.uuid ?? undefined,
+            eventTimestamp: f.eventTimestamp,
+          }));
+
+        // Track that face across cameras, ordered in time.
+        const seed = facesAtDoor.find((f) => f.faceEventUuid);
+        if (seed?.faceEventUuid) {
+          const similar = await searchSimilarFaces(seed.faceEventUuid, timeZone, requestModifiers, sessionId);
+          sightings = similar
+            .map((s) => ({
+              deviceUuid: s.deviceUuid,
+              datetime: s.eventTimestamp,
+              timestampMs: s.eventTimestampMs,
+              similarity: s.similarity,
+              personUuid: s.personUuid,
+            }))
+            .sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
+        }
+      } catch {
+        // Face enrichment is best-effort — never fail the whole response over it.
+      }
+    }
+
+    const last = sightings.length ? sightings[sightings.length - 1] : undefined;
+    incidents.push({
+      cardholderOfRecord: e.cardholderName,
+      badgeStatus: e.badgeStatus,
+      datetime: e.datetime,
+      timestampMs: e.timestampMs,
+      deviceUuid: e.deviceUuid,
+      area: e.areaEntering ?? e.areaExiting,
+      clipHint,
+      stillHint,
+      facesAtDoor,
+      sightings,
+      lastKnownSighting: last ? { deviceUuid: last.deviceUuid, datetime: last.datetime } : undefined,
+    });
+  }
+
+  return { incidents, count: incidents.length };
+}

--- a/src/tools-console/lost-badge-tool.ts
+++ b/src/tools-console/lost-badge-tool.ts
@@ -1,0 +1,62 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getLostBadgeResponse } from "../api/lost-badge-tool-api.js";
+import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/lost-badge-tool-types.js";
+import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+
+const TOOL_NAME = "lost-badge-tool";
+
+const TOOL_DESCRIPTION = `
+Lost / stolen-badge live response for Honeywell OnGuard (Lenel) access. Use for "a lost badge was just used —
+who is it and where did they go?", or to review lost/inactive-badge use over a window.
+
+For each lost/inactive-badge use it returns:
+- cardholderOfRecord (who the badge belongs to — may NOT be who used it) and badgeStatus
+- the door deviceUuid + time, plus clipHint / stillHint for the door footage
+- facesAtDoor: the face(s) captured at the door at that moment — a recognized name, or UNIDENTIFIED (an unknown
+  face on a valid badge is the strongest stolen/shared-badge signal), with a thumbnail
+- sightings: that same face tracked across cameras, ordered in time, ending in lastKnownSighting (last-known location)
+
+Resolve relative times (e.g. "in the last hour") to ISO 8601 first via the timestamp tool.
+
+To present: show the door still/clip (camera-tool image / clips-tool createClip with the hints), the face at the
+door, and the cross-camera track to last-known location. Detection + door evidence are reliable; the face track
+depends on face-recognition coverage, so treat it as investigative, not proof.
+`;
+
+const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
+  const { requestModifiers, sessionId } = extractFromToolExtra(_extra);
+
+  try {
+    const result = await getLostBadgeResponse(
+      {
+        area: args.area ?? undefined,
+        locationUuids: args.locationUuids ?? undefined,
+        deviceUuids: args.deviceUuids ?? undefined,
+        afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
+        beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        faceWindowSeconds: args.faceWindowSeconds ?? undefined,
+        limit: args.limit ?? undefined,
+      },
+      args.timeZone ?? "UTC",
+      requestModifiers,
+      sessionId
+    );
+    return createToolStructuredContent<OUTPUT_SCHEMA>(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return createToolStructuredContent<OUTPUT_SCHEMA>({ error: message });
+  }
+};
+
+export function createTool(server: McpServer) {
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description: TOOL_DESCRIPTION,
+      inputSchema: TOOL_ARGS,
+      outputSchema: OUTPUT_SCHEMA.shape,
+    },
+    TOOL_HANDLER
+  );
+}

--- a/src/types/lost-badge-tool-types.ts
+++ b/src/types/lost-badge-tool-types.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+import { createUuidSchema } from "../types.js";
+import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
+
+export const TOOL_ARGS = {
+  area: z.string().nullable().describe("Optional: restrict to events entering this area (full-text)."),
+  locationUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these location UUIDs."),
+  deviceUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these camera UUIDs."),
+  startTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("Start of the window to scan for lost/inactive-badge use (inclusive). " + ISOTimestampFormatDescription),
+  endTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("End of the window (inclusive). " + ISOTimestampFormatDescription),
+  faceWindowSeconds: z
+    .number()
+    .nullable()
+    .describe("± seconds around each badge event to look for the face at the door (default 30)."),
+  limit: z.number().nullable().describe("Max badge events to scan in the window (default 50)."),
+  timeZone: z
+    .string()
+    .nullable()
+    .describe("IANA timezone for formatting times, e.g. America/New_York. Defaults to UTC."),
+};
+
+const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
+export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
+
+const ClipHintSchema = z.object({ deviceUuid: z.string(), startTimeMs: z.number(), endTimeMs: z.number() });
+const StillHintSchema = z.object({ deviceUuid: z.string(), timestampMs: z.number() });
+
+const FaceAtDoorSchema = z.object({
+  faceName: z.string().optional().describe('Recognized name, or absent/UNIDENTIFIED if no enrolled match.'),
+  personUuid: z.string().optional(),
+  thumbnailS3Key: z.string().optional().describe("Face crop thumbnail key for display."),
+  faceEventUuid: z.string().optional(),
+  eventTimestamp: z.string().optional(),
+});
+
+const SightingSchema = z.object({
+  deviceUuid: z.string().optional().describe("Camera where the same face was seen."),
+  datetime: z.string().optional(),
+  timestampMs: z.number().optional(),
+  similarity: z.number().optional(),
+  personUuid: z.string().optional(),
+});
+
+export const LostBadgeIncidentSchema = z.object({
+  cardholderOfRecord: z.string().optional().describe("The cardholder the badge is registered to (may not be who used it)."),
+  badgeStatus: z.string().optional(),
+  datetime: z.string().optional(),
+  timestampMs: z.number().optional(),
+  deviceUuid: z.string().optional().describe("Door camera. Pass to camera-tool (image) / clips-tool (createClip)."),
+  area: z.string().optional(),
+  clipHint: ClipHintSchema.optional(),
+  stillHint: StillHintSchema.optional(),
+  facesAtDoor: z.array(FaceAtDoorSchema).optional().describe("Face(s) captured at the door at the time of use."),
+  sightings: z
+    .array(SightingSchema)
+    .optional()
+    .describe("Same face seen across cameras, ordered in time — the track after the door."),
+  lastKnownSighting: z
+    .object({ deviceUuid: z.string().optional(), datetime: z.string().optional() })
+    .optional()
+    .describe("Most recent sighting — the person's last-known location."),
+});
+
+export const OUTPUT_SCHEMA = z.object({
+  incidents: z.array(LostBadgeIncidentSchema).optional(),
+  count: z.number().optional(),
+  error: z.string().optional(),
+});
+export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;


### PR DESCRIPTION
## What
Adds **`lost-badge-tool`** (Feature 5, Tier A) — lost/stolen-badge live response across LenelS2 (OnGuard · NetBox · Elements).

For each lost/inactive-badge use in the window it returns:
- **cardholderOfRecord** (who the badge belongs to — may not be who used it) + badgeStatus
- the **door** deviceUuid/time + `clipHint`/`stillHint`
- **facesAtDoor** — the face(s) captured at the door: a recognized name, or **UNIDENTIFIED** (unknown face on a valid badge = strongest stolen/shared-badge signal), with a thumbnail
- **sightings** — that same face tracked **across cameras**, ordered in time, ending in **lastKnownSighting**

## How
Orchestration over existing APIs: `searchOnGuardEvents` (anomalyOnly → filter to non-active badge) → door media via the `badge-correlation` helper → `getFaceEvents` over a ±window, matched to the door camera client-side (the faces tool can't filter by device) → `searchSimilarFaces` from the door face for the cross-camera track. Detection + door evidence are exact; the face track is best-effort (depends on FR coverage) and framed as investigative.

Additive change to `faces-tool-api.searchSimilarFaces`: now also returns `deviceUuid` + `eventTimestampMs` so the track has a camera and can be time-ordered. Harmless to the existing faces-tool (extra fields).

## Notes
- **Stacked on PR #30** for the shared helper; retarget to `main` once #30 merges.
- `tsc` clean; registers (34 tools on this branch). **Open for sandbox validation before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)