### PR TITLE
fix(telemetry): end mcp.tool.call spans so they actually export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@opentelemetry/api": "^1.9.0",
         "axios": "^1.11.0",
         "cheerio": "^1.1.2",
         "chrono-node": "^2.8.0",
@@ -29,6 +28,7 @@
         "mcp-server-rhombus": "dist/index.js"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/luxon": "^3.6.2",
@@ -41,6 +41,14 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -687,6 +695,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@opentelemetry/api": "^1.9.0",
     "axios": "^1.11.0",
     "cheerio": "^1.1.2",
     "chrono-node": "^2.8.0",
@@ -66,6 +65,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/luxon": "^3.6.2",
@@ -78,5 +78,13 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   }
 }

--- a/src/telemetry/tracingProxy.ts
+++ b/src/telemetry/tracingProxy.ts
@@ -1,6 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { SpanStatusCode, trace, type Span } from "@opentelemetry/api";
+import {
+  context,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  TraceFlags,
+  type Span,
+} from "@opentelemetry/api";
 
 import { resolveSessionIdentity } from "../api/get-accessible-apps.js";
 import { logger } from "../logger.js";
@@ -8,9 +15,23 @@ import { extractFromToolExtra } from "../util.js";
 
 const TRACER_NAME = "rhombus-node-mcp";
 const TOOL_CALL_SPAN = "mcp.tool.call";
+const INVALID_TRACE_ID = "00000000000000000000000000000000";
+
+let warnedNoopTracer = false;
 
 // biome-ignore lint/suspicious/noExplicitAny: MCP tool handler signature is dynamic
 type ToolHandler = (args: any, extra: unknown) => Promise<CallToolResult> | CallToolResult;
+
+function warnIfNoopTracer(span: Span): void {
+  if (warnedNoopTracer) return;
+  const { traceId, traceFlags } = span.spanContext();
+  if (traceId === INVALID_TRACE_ID || traceFlags === TraceFlags.NONE) {
+    warnedNoopTracer = true;
+    logger.warn(
+      "📡 OpenTelemetry custom spans are no-ops — @opentelemetry/api is not sharing the SDK TracerProvider. Check for duplicate @opentelemetry/api in node_modules.",
+    );
+  }
+}
 
 function setArgKeys(span: Span, args: unknown): void {
   if (args && typeof args === "object") {
@@ -41,39 +62,50 @@ async function attachSessionIdentity(span: Span, extra: unknown): Promise<void> 
 function wrapHandler(toolName: string, handler: ToolHandler): ToolHandler {
   return async (args: unknown, extra: unknown) => {
     const tracer = trace.getTracer(TRACER_NAME);
+    const parentContext = context.active();
 
-    return tracer.startActiveSpan(TOOL_CALL_SPAN, async (span) => {
-      const start = Date.now();
-      span.setAttribute("mcp.tool.name", toolName);
-      span.setAttribute("mcp.transport", process.env.TRANSPORT_TYPE ?? "stdio");
-      setArgKeys(span, args);
+    return tracer.startActiveSpan(
+      TOOL_CALL_SPAN,
+      { kind: SpanKind.INTERNAL },
+      parentContext,
+      async (span) => {
+        warnIfNoopTracer(span);
 
-      try {
-        await attachSessionIdentity(span, extra);
+        const start = Date.now();
+        span.setAttribute("mcp.tool.name", toolName);
+        span.setAttribute("mcp.transport", process.env.TRANSPORT_TYPE ?? "stdio");
+        setArgKeys(span, args);
 
-        const result = await handler(args, extra);
-        const isError =
-          result && typeof result === "object" && (result as CallToolResult).isError;
-        span.setAttribute("mcp.tool.success", !isError);
-        if (isError) {
+        try {
+          await attachSessionIdentity(span, extra);
+
+          const result = await handler(args, extra);
+          const isError =
+            result && typeof result === "object" && (result as CallToolResult).isError;
+          span.setAttribute("mcp.tool.success", !isError);
+          if (isError) {
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: "tool returned isError",
+            });
+          } else {
+            span.setStatus({ code: SpanStatusCode.OK });
+          }
+          return result;
+        } catch (error) {
+          span.setAttribute("mcp.tool.success", false);
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: "tool returned isError",
+            message: error instanceof Error ? error.message : String(error),
           });
+          throw error;
+        } finally {
+          span.setAttribute("mcp.tool.duration_ms", Date.now() - start);
+          span.end();
         }
-        return result;
-      } catch (error) {
-        span.setAttribute("mcp.tool.success", false);
-        span.recordException(error instanceof Error ? error : new Error(String(error)));
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      } finally {
-        span.setAttribute("mcp.tool.duration_ms", Date.now() - start);
-      }
-    });
+      },
+    );
   };
 }
 


### PR DESCRIPTION
wrapHandler started an mcp.tool.call span via startActiveSpan but never called span.end(). SimpleSpanProcessor (used by the deploy host's otel-init.mjs) only exports a span on its onEnd hook, so every tool-call span was created and dropped — the /mcp request_handler spans from auto-instrumentation showed up but tool calls never did.

Call span.end() in the finally block.