### PR TITLE
feat(onguard): MIND tools — follow-the-badge, access anomalies, lost-badge (F3/F4/F5)

### DIFF
--- a/src/api/access-anomaly-tool-api.ts
+++ b/src/api/access-anomaly-tool-api.ts
@@ -1,0 +1,158 @@
+import { buildMediaHints } from "./badge-correlation.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import type { RequestModifiers } from "../util.js";
+
+export interface GetAccessAnomaliesArgs {
+  area?: string;
+  locationUuids?: string[];
+  deviceUuids?: string[];
+  afterMs?: number;
+  beforeMs?: number;
+  rules?: string[];
+  baselineDays?: number;
+  offHoursStartHour?: number;
+  offHoursEndHour?: number;
+  impossibleTravelMaxSeconds?: number;
+  limit?: number;
+}
+
+type OnGuardEvent = Awaited<ReturnType<typeof searchOnGuardEvents>>["events"][number];
+
+interface Finding {
+  cardholderName?: string;
+  rule: string;
+  severity: "high" | "medium";
+  datetime?: string;
+  timestampMs?: number;
+  deviceUuid?: string;
+  area?: string;
+  rationale: string;
+  clipHint?: ReturnType<typeof buildMediaHints>["clipHint"];
+  stillHint?: ReturnType<typeof buildMediaHints>["stillHint"];
+}
+
+const ALL_RULES = [
+  "lost_or_inactive_badge",
+  "entry_not_made",
+  "off_hours",
+  "impossible_travel",
+  "area_novelty",
+];
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Flags anomalous OnGuard access events over a window: deterministic rules (lost/inactive badge, no-entry,
+ * off-hours, impossible travel, first-time-in-area vs a baseline) computed over searchOnGuardEvents, each
+ * finding carrying the still/clip hints to confirm it. The agent narrates/triages from here.
+ */
+export async function getAccessAnomalies(
+  args: GetAccessAnomaliesArgs,
+  timeZone: string,
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+) {
+  const rules = new Set(args.rules && args.rules.length ? args.rules : ALL_RULES);
+  const offStart = args.offHoursStartHour ?? 7;
+  const offEnd = args.offHoursEndHour ?? 19;
+  const maxTravelSec = args.impossibleTravelMaxSeconds ?? 30;
+  const baselineDays = args.baselineDays ?? 30;
+  const scope = { area: args.area, locationUuids: args.locationUuids, deviceUuids: args.deviceUuids };
+
+  const { events } = await searchOnGuardEvents(
+    { ...scope, afterMs: args.afterMs, beforeMs: args.beforeMs, limit: args.limit ?? 500 },
+    timeZone,
+    requestModifiers,
+    sessionId
+  );
+
+  // Baseline area-set per cardholder (for area_novelty).
+  const baselineAreas = new Map<string, Set<string>>();
+  if (rules.has("area_novelty") && baselineDays > 0 && args.afterMs != null) {
+    const { events: baseEvents } = await searchOnGuardEvents(
+      { ...scope, afterMs: args.afterMs - baselineDays * DAY_MS, beforeMs: args.afterMs, limit: 1000 },
+      timeZone,
+      requestModifiers,
+      sessionId
+    );
+    for (const e of baseEvents) {
+      if (!e.cardholderName || !e.areaEntering) continue;
+      const set = baselineAreas.get(e.cardholderName) ?? new Set<string>();
+      set.add(e.areaEntering);
+      baselineAreas.set(e.cardholderName, set);
+    }
+  }
+
+  const hourFmt = new Intl.DateTimeFormat("en-US", { timeZone, hour: "2-digit", hourCycle: "h23" });
+  const localHour = (ms: number) => parseInt(hourFmt.format(new Date(ms)), 10);
+
+  const findings: Finding[] = [];
+  const seen = new Set<string>();
+  const add = (e: OnGuardEvent, rule: string, severity: "high" | "medium", rationale: string) => {
+    const key = `${e.cardholderName ?? ""}|${rule}|${e.timestampMs ?? ""}|${e.areaEntering ?? ""}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    const { clipHint, stillHint } = buildMediaHints({ deviceUuid: e.deviceUuid, timestampMs: e.timestampMs });
+    findings.push({
+      cardholderName: e.cardholderName,
+      rule,
+      severity,
+      datetime: e.datetime,
+      timestampMs: e.timestampMs,
+      deviceUuid: e.deviceUuid,
+      area: e.areaEntering ?? e.areaExiting,
+      rationale,
+      clipHint,
+      stillHint,
+    });
+  };
+
+  for (const e of events) {
+    const at = e.areaEntering ? ` at "${e.areaEntering}"` : "";
+    if (rules.has("lost_or_inactive_badge") && e.badgeStatus && e.badgeStatus.toLowerCase() !== "active") {
+      add(e, "lost_or_inactive_badge", "high", `Badge status "${e.badgeStatus}" used${at}.`);
+    }
+    if (rules.has("entry_not_made") && e.entryMade === false) {
+      add(e, "entry_not_made", "medium", `Access granted but no entry made${at} — possible tailgating or aborted entry.`);
+    }
+    if (rules.has("off_hours") && e.timestampMs != null) {
+      const h = localHour(e.timestampMs);
+      if (h < offStart || h >= offEnd) {
+        add(e, "off_hours", "medium", `Entry ${e.datetime ?? `${h}:00`} is outside business hours (${offStart}:00–${offEnd}:00)${at}.`);
+      }
+    }
+    if (rules.has("area_novelty") && baselineAreas.size > 0 && e.cardholderName && e.areaEntering) {
+      const base = baselineAreas.get(e.cardholderName);
+      if (base && !base.has(e.areaEntering)) {
+        add(e, "area_novelty", "high", `First entry to "${e.areaEntering}" — not in ${e.cardholderName}'s prior ${baselineDays}-day pattern.`);
+      }
+    }
+  }
+
+  // Impossible travel: per cardholder, consecutive taps in different areas within the window.
+  if (rules.has("impossible_travel")) {
+    const byPerson = new Map<string, OnGuardEvent[]>();
+    for (const e of events) {
+      if (!e.cardholderName || e.timestampMs == null) continue;
+      const arr = byPerson.get(e.cardholderName) ?? [];
+      arr.push(e);
+      byPerson.set(e.cardholderName, arr);
+    }
+    for (const [name, evs] of byPerson) {
+      const sorted = evs.slice().sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
+      for (let i = 1; i < sorted.length; i++) {
+        const a = sorted[i - 1];
+        const b = sorted[i];
+        const gapSec = ((b.timestampMs ?? 0) - (a.timestampMs ?? 0)) / 1000;
+        if (a.areaEntering && b.areaEntering && a.areaEntering !== b.areaEntering && gapSec <= maxTravelSec) {
+          add(b, "impossible_travel", "high", `${name} at "${a.areaEntering}" then "${b.areaEntering}" ${Math.round(gapSec)}s apart — physically implausible for one person.`);
+        }
+      }
+    }
+  }
+
+  const sev = (s: string) => (s === "high" ? 0 : 1);
+  findings.sort((a, b) => sev(a.severity) - sev(b.severity) || (b.timestampMs ?? 0) - (a.timestampMs ?? 0));
+
+  return { findings, eventsAnalyzed: events.length };
+}

--- a/src/api/badge-correlation.ts
+++ b/src/api/badge-correlation.ts
@@ -1,0 +1,63 @@
+/**
+ * Keystone correlation helper for the OnGuard feature set.
+ *
+ * Given a badge-event-like entry (a camera `deviceUuid` + a `timestampMs`), produce the media hints
+ * the agent needs to *show* the moment: a still (camera-tool `image`) and a short clip window
+ * (clips-tool `createClip`). Pure and reusable — the follow-the-badge timeline, anomaly review, and
+ * lost-badge tracking all turn badge events into "here's the picture/video" the same way.
+ *
+ * Kept deliberately small and side-effect-free. Richer correlation (co-located face events,
+ * people-count in the window) layers on top of this when those features land.
+ */
+
+export interface BadgeEventLike {
+  /** The camera that saw the event. Some OnGuard events aren't mapped to a camera. */
+  deviceUuid?: string;
+  /** Event time, epoch ms. */
+  timestampMs?: number;
+}
+
+export interface ClipHint {
+  /** The camera that saw the event. Pass to clips-tool `createClip`. */
+  deviceUuid: string;
+  startTimeMs: number;
+  endTimeMs: number;
+}
+
+export interface StillHint {
+  /** The camera that saw the event. Pass to camera-tool (requestType `image`). */
+  deviceUuid: string;
+  timestampMs: number;
+}
+
+export interface MediaHints {
+  clipHint?: ClipHint;
+  stillHint?: StillHint;
+}
+
+export const DEFAULT_CLIP_PADDING_SECONDS = 15;
+
+/**
+ * Build still + clip hints for a single badge event. Returns empty hints (no clip/still) when the
+ * event lacks a camera or timestamp, so callers can render those events without media gracefully.
+ */
+export function buildMediaHints(
+  event: BadgeEventLike,
+  clipPaddingSeconds: number = DEFAULT_CLIP_PADDING_SECONDS
+): MediaHints {
+  if (!event.deviceUuid || event.timestampMs == null) {
+    return {};
+  }
+  const padMs = Math.max(0, clipPaddingSeconds) * 1000;
+  return {
+    clipHint: {
+      deviceUuid: event.deviceUuid,
+      startTimeMs: event.timestampMs - padMs,
+      endTimeMs: event.timestampMs + padMs,
+    },
+    stillHint: {
+      deviceUuid: event.deviceUuid,
+      timestampMs: event.timestampMs,
+    },
+  };
+}

--- a/src/api/badge-timeline-tool-api.ts
+++ b/src/api/badge-timeline-tool-api.ts
@@ -1,0 +1,86 @@
+import { buildMediaHints } from "./badge-correlation.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import type { RequestModifiers } from "../util.js";
+
+export interface GetBadgeTimelineArgs {
+  cardholderQuery: string;
+  locationUuids?: string[];
+  afterMs?: number;
+  beforeMs?: number;
+  clipPaddingSeconds?: number;
+  limit?: number;
+}
+
+/**
+ * Reconstructs a single cardholder's movements as a chronological timeline of OnGuard badge taps,
+ * each with the still/clip hints needed to show what happened. Pure orchestration over
+ * searchOnGuardEvents + the shared correlation helper.
+ */
+export async function getBadgeTimeline(
+  args: GetBadgeTimelineArgs,
+  timeZone: string,
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+) {
+  const { events } = await searchOnGuardEvents(
+    {
+      cardholderQuery: args.cardholderQuery,
+      locationUuids: args.locationUuids,
+      afterMs: args.afterMs,
+      beforeMs: args.beforeMs,
+      limit: args.limit ?? 200,
+    },
+    timeZone,
+    requestModifiers,
+    sessionId
+  );
+
+  // searchOnGuardEvents returns newest-first; a timeline reads chronologically.
+  const ordered = events
+    .filter((e) => e.timestampMs != null)
+    .sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
+
+  const stops = ordered.map((e, i) => {
+    const next = ordered[i + 1];
+    const gapToNextSeconds =
+      next?.timestampMs != null && e.timestampMs != null
+        ? Math.round((next.timestampMs - e.timestampMs) / 1000)
+        : undefined;
+    const { clipHint, stillHint } = buildMediaHints(
+      { deviceUuid: e.deviceUuid, timestampMs: e.timestampMs },
+      args.clipPaddingSeconds
+    );
+    return {
+      timestampMs: e.timestampMs,
+      datetime: e.datetime,
+      deviceUuid: e.deviceUuid,
+      area: e.areaEntering ?? e.areaExiting,
+      label: e.label,
+      isAnomaly: e.isAnomaly,
+      clipHint,
+      stillHint,
+      gapToNextSeconds,
+    };
+  });
+
+  // The sequence of areas traversed, collapsing consecutive repeats.
+  const path: string[] = [];
+  for (const stop of stops) {
+    if (stop.area && stop.area !== path[path.length - 1]) {
+      path.push(stop.area);
+    }
+  }
+
+  // cardholderQuery is full-text, so it can match more than one person — surface that so the agent
+  // can disambiguate rather than silently merge two people's movements.
+  const distinctCardholders = [
+    ...new Set(ordered.map((e) => e.cardholderName).filter((n): n is string => !!n)),
+  ];
+
+  return {
+    cardholderName: distinctCardholders[0],
+    ambiguousCardholders: distinctCardholders.length > 1 ? distinctCardholders : undefined,
+    stops,
+    path,
+  };
+}

--- a/src/api/faces-tool-api.ts
+++ b/src/api/faces-tool-api.ts
@@ -143,8 +143,10 @@ export async function searchSimilarFaces(
 	if (res.error) throw new Error(JSON.stringify(res));
 	return (res.faceEvents || []).map((event: any) => ({
 		uuid: event.uuid ?? undefined,
+		deviceUuid: event.deviceUuid ?? undefined,
 		personUuid: event.personUuid ?? undefined,
 		similarity: event.similarity ?? undefined,
+		eventTimestampMs: event.eventTimestamp ?? undefined,
 		eventTimestamp: event.eventTimestamp
 			? formatTimestamp(event.eventTimestamp, timeZone)
 			: undefined,

--- a/src/api/lost-badge-tool-api.ts
+++ b/src/api/lost-badge-tool-api.ts
@@ -1,0 +1,145 @@
+import { buildMediaHints, type ClipHint, type StillHint } from "./badge-correlation.js";
+import { getFaceEvents, searchSimilarFaces } from "./faces-tool-api.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import type { RequestModifiers } from "../util.js";
+
+export interface GetLostBadgeResponseArgs {
+  area?: string;
+  locationUuids?: string[];
+  deviceUuids?: string[];
+  afterMs?: number;
+  beforeMs?: number;
+  faceWindowSeconds?: number;
+  limit?: number;
+}
+
+interface FaceAtDoor {
+  faceName?: string;
+  personUuid?: string;
+  thumbnailS3Key?: string;
+  faceEventUuid?: string;
+  eventTimestamp?: string;
+}
+interface Sighting {
+  deviceUuid?: string;
+  datetime?: string;
+  timestampMs?: number;
+  similarity?: number;
+  personUuid?: string;
+}
+interface LostBadgeIncident {
+  cardholderOfRecord?: string;
+  badgeStatus?: string;
+  datetime?: string;
+  timestampMs?: number;
+  deviceUuid?: string;
+  area?: string;
+  clipHint?: ClipHint;
+  stillHint?: StillHint;
+  facesAtDoor: FaceAtDoor[];
+  sightings: Sighting[];
+  lastKnownSighting?: { deviceUuid?: string; datetime?: string };
+}
+
+/**
+ * Lost / stolen-badge live response. Finds recent lost/inactive-badge use, and for each: the door clip/still,
+ * the face captured at the door (identified or UNIDENTIFIED), and a cross-camera track of that same face
+ * (via similar-face search) ordered to a last-known location. Detection + door evidence are exact; the track
+ * is best-effort (depends on face capture + recognition coverage).
+ */
+export async function getLostBadgeResponse(
+  args: GetLostBadgeResponseArgs,
+  timeZone: string,
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+): Promise<{ incidents: LostBadgeIncident[]; count: number }> {
+  const scope = { area: args.area, locationUuids: args.locationUuids, deviceUuids: args.deviceUuids };
+  const { events } = await searchOnGuardEvents(
+    { ...scope, anomalyOnly: true, afterMs: args.afterMs, beforeMs: args.beforeMs, limit: args.limit ?? 50 },
+    timeZone,
+    requestModifiers,
+    sessionId
+  );
+
+  // anomalyOnly returns lost-badge AND no-entry anomalies; keep the lost/inactive-badge ones.
+  const lostEvents = events.filter((e) => e.badgeStatus && e.badgeStatus.toLowerCase() !== "active");
+  const winMs = (args.faceWindowSeconds ?? 30) * 1000;
+
+  const incidents: LostBadgeIncident[] = [];
+  for (const e of lostEvents) {
+    const { clipHint, stillHint } = buildMediaHints({ deviceUuid: e.deviceUuid, timestampMs: e.timestampMs });
+    let facesAtDoor: FaceAtDoor[] = [];
+    let sightings: Sighting[] = [];
+
+    if (e.deviceUuid && e.timestampMs != null) {
+      try {
+        // Face(s) at the door: query by time window (the faces tool can't filter by device), then match
+        // the door camera client-side.
+        const { faceEvents } = await getFaceEvents(
+          {
+            pageRequest: { lastEvaluatedKey: null, maxPageSize: 75 },
+            searchFilter: {
+              faceNameContains: null,
+              faceNames: [],
+              hasEmbedding: null,
+              hasName: null,
+              labels: [],
+              locationUuids: [],
+              personUuids: [],
+              timestampFilter: {
+                rangeStart: new Date(e.timestampMs - winMs).toISOString(),
+                rangeEnd: new Date(e.timestampMs + winMs).toISOString(),
+              },
+            },
+          },
+          timeZone,
+          requestModifiers,
+          sessionId
+        );
+        facesAtDoor = faceEvents
+          .filter((f) => f.deviceUuid === e.deviceUuid)
+          .map((f) => ({
+            faceName: f.faceName ?? undefined,
+            personUuid: f.personUuid ?? undefined,
+            thumbnailS3Key: f.thumbnailS3Key ?? undefined,
+            faceEventUuid: f.uuid ?? undefined,
+            eventTimestamp: f.eventTimestamp,
+          }));
+
+        // Track that face across cameras, ordered in time.
+        const seed = facesAtDoor.find((f) => f.faceEventUuid);
+        if (seed?.faceEventUuid) {
+          const similar = await searchSimilarFaces(seed.faceEventUuid, timeZone, requestModifiers, sessionId);
+          sightings = similar
+            .map((s) => ({
+              deviceUuid: s.deviceUuid,
+              datetime: s.eventTimestamp,
+              timestampMs: s.eventTimestampMs,
+              similarity: s.similarity,
+              personUuid: s.personUuid,
+            }))
+            .sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
+        }
+      } catch {
+        // Face enrichment is best-effort — never fail the whole response over it.
+      }
+    }
+
+    const last = sightings.length ? sightings[sightings.length - 1] : undefined;
+    incidents.push({
+      cardholderOfRecord: e.cardholderName,
+      badgeStatus: e.badgeStatus,
+      datetime: e.datetime,
+      timestampMs: e.timestampMs,
+      deviceUuid: e.deviceUuid,
+      area: e.areaEntering ?? e.areaExiting,
+      clipHint,
+      stillHint,
+      facesAtDoor,
+      sightings,
+      lastKnownSighting: last ? { deviceUuid: last.deviceUuid, datetime: last.datetime } : undefined,
+    });
+  }
+
+  return { incidents, count: incidents.length };
+}

--- a/src/api/onguard-tool-api.ts
+++ b/src/api/onguard-tool-api.ts
@@ -55,8 +55,12 @@ export async function searchOnGuardEvents(
     timestampMs: e.timestampMs ?? undefined,
     datetime: e.timestampMs != null ? formatTimestamp(e.timestampMs, timeZone) : undefined,
     deviceUuid: e.deviceUuid ?? undefined,
-    label: e.customDisplayName ?? undefined,
-    cardholderName: e.customDescription ?? undefined,
+    label: e.customDisplayName ?? e.objectType ?? undefined,
+    // Dedicated-event-types put the cardholder in its own `cardholderName` field (customDescription
+    // is null on ONGUARD_* docs); keep customDescription as a legacy fallback. The generated schema
+    // predates the field, so read it through a cast until `assets/openapi.json` is regenerated.
+    cardholderName:
+      (e as { cardholderName?: string | null }).cardholderName ?? e.customDescription ?? undefined,
     badgeStatus: e.badgeStatus ?? undefined,
     badgeType: e.badgeType ?? undefined,
     areaEntering: e.areaEntering ?? undefined,

--- a/src/tools-console/access-anomaly-tool.ts
+++ b/src/tools-console/access-anomaly-tool.ts
@@ -1,0 +1,68 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getAccessAnomalies } from "../api/access-anomaly-tool-api.js";
+import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/access-anomaly-tool-types.js";
+import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+
+const TOOL_NAME = "access-anomaly-tool";
+
+const TOOL_DESCRIPTION = `
+Scans Honeywell OnGuard (Lenel) access events over a time window and flags anomalous badge activity. Use for
+"find unusual badge activity", "anything suspicious in access this week", or proactive access review.
+
+Runs deterministic rules and returns ranked findings (high severity first):
+- lost_or_inactive_badge: a non-active badge (lost/suspended) was used
+- entry_not_made: access granted but no entry made (possible tailgating)
+- off_hours: entry outside business hours (configurable)
+- impossible_travel: one cardholder at two different areas seconds apart
+- area_novelty: a cardholder's first-ever entry to an area vs their prior history (needs a baseline window)
+
+Each finding includes cardholderName, the rule, severity, datetime, area, the camera deviceUuid, a plain-language
+rationale, and clip/still hints. Resolve relative times (e.g. "this week") to ISO 8601 first via the timestamp tool.
+
+This is a triage aid: present findings grouped by severity, and for the notable ones call the camera-tool
+(requestType "image", cameraUuid = finding.deviceUuid, timestamp = finding.timestampMs) and/or clips-tool
+("createClip" using finding.clipHint) — in PARALLEL — so a human can confirm. Don't assert wrongdoing; surface the
+evidence.
+`;
+
+const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
+  const { requestModifiers, sessionId } = extractFromToolExtra(_extra);
+
+  try {
+    const result = await getAccessAnomalies(
+      {
+        area: args.area ?? undefined,
+        locationUuids: args.locationUuids ?? undefined,
+        deviceUuids: args.deviceUuids ?? undefined,
+        afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
+        beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        rules: args.rules ?? undefined,
+        baselineDays: args.baselineDays ?? undefined,
+        offHoursStartHour: args.offHoursStartHour ?? undefined,
+        offHoursEndHour: args.offHoursEndHour ?? undefined,
+        impossibleTravelMaxSeconds: args.impossibleTravelMaxSeconds ?? undefined,
+        limit: args.limit ?? undefined,
+      },
+      args.timeZone ?? "UTC",
+      requestModifiers,
+      sessionId
+    );
+    return createToolStructuredContent<OUTPUT_SCHEMA>(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return createToolStructuredContent<OUTPUT_SCHEMA>({ error: message });
+  }
+};
+
+export function createTool(server: McpServer) {
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description: TOOL_DESCRIPTION,
+      inputSchema: TOOL_ARGS,
+      outputSchema: OUTPUT_SCHEMA.shape,
+    },
+    TOOL_HANDLER
+  );
+}

--- a/src/tools-console/badge-timeline-tool.ts
+++ b/src/tools-console/badge-timeline-tool.ts
@@ -1,0 +1,65 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getBadgeTimeline } from "../api/badge-timeline-tool-api.js";
+import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/badge-timeline-tool-types.js";
+import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+
+const TOOL_NAME = "badge-timeline-tool";
+
+const TOOL_DESCRIPTION = `
+Reconstructs one person's movements through a building from their Honeywell OnGuard (Lenel) badge taps.
+Use this for incident reconstruction / "follow the badge" requests, e.g. "reconstruct Eve's movements
+yesterday" or "where did this cardholder go".
+
+Returns the cardholder's badge taps in CHRONOLOGICAL order (oldest first), each with:
+- datetime / timestampMs and the area entered
+- deviceUuid: the camera at that door
+- clipHint (camera + start/end window) and stillHint (camera + timestamp)
+- gapToNextSeconds: time until the next tap (a large gap = unobserved movement between doors)
+plus a "path" array summarizing the areas traversed in order.
+
+Resolve relative times like "yesterday" to ISO 8601 first (use the timestamp tool), then pass
+startTime/endTime. cardholderQuery is a full-text name match; if "ambiguousCardholders" is returned the
+query matched more than one person — ask the user which one before trusting the timeline.
+
+IMPORTANT — to show the movement visually: for each stop (or the key transitions), call the camera-tool
+(requestType "image", cameraUuid = stop.deviceUuid, timestamp = stop.timestampMs) for a still you can see,
+and/or the clips-tool (requestType "createClip", using stop.clipHint) for video. Issue those per-stop
+media calls in PARALLEL, then present the timeline as a chronological narrative.
+`;
+
+const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
+  const { requestModifiers, sessionId } = extractFromToolExtra(_extra);
+
+  try {
+    const result = await getBadgeTimeline(
+      {
+        cardholderQuery: args.cardholderQuery,
+        locationUuids: args.locationUuids ?? undefined,
+        afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
+        beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        clipPaddingSeconds: args.clipPaddingSeconds ?? undefined,
+        limit: args.limit ?? undefined,
+      },
+      args.timeZone ?? "UTC",
+      requestModifiers,
+      sessionId
+    );
+    return createToolStructuredContent<OUTPUT_SCHEMA>(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return createToolStructuredContent<OUTPUT_SCHEMA>({ error: message });
+  }
+};
+
+export function createTool(server: McpServer) {
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description: TOOL_DESCRIPTION,
+      inputSchema: TOOL_ARGS,
+      outputSchema: OUTPUT_SCHEMA.shape,
+    },
+    TOOL_HANDLER
+  );
+}

--- a/src/tools-console/lost-badge-tool.ts
+++ b/src/tools-console/lost-badge-tool.ts
@@ -1,0 +1,62 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getLostBadgeResponse } from "../api/lost-badge-tool-api.js";
+import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/lost-badge-tool-types.js";
+import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+
+const TOOL_NAME = "lost-badge-tool";
+
+const TOOL_DESCRIPTION = `
+Lost / stolen-badge live response for Honeywell OnGuard (Lenel) access. Use for "a lost badge was just used —
+who is it and where did they go?", or to review lost/inactive-badge use over a window.
+
+For each lost/inactive-badge use it returns:
+- cardholderOfRecord (who the badge belongs to — may NOT be who used it) and badgeStatus
+- the door deviceUuid + time, plus clipHint / stillHint for the door footage
+- facesAtDoor: the face(s) captured at the door at that moment — a recognized name, or UNIDENTIFIED (an unknown
+  face on a valid badge is the strongest stolen/shared-badge signal), with a thumbnail
+- sightings: that same face tracked across cameras, ordered in time, ending in lastKnownSighting (last-known location)
+
+Resolve relative times (e.g. "in the last hour") to ISO 8601 first via the timestamp tool.
+
+To present: show the door still/clip (camera-tool image / clips-tool createClip with the hints), the face at the
+door, and the cross-camera track to last-known location. Detection + door evidence are reliable; the face track
+depends on face-recognition coverage, so treat it as investigative, not proof.
+`;
+
+const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
+  const { requestModifiers, sessionId } = extractFromToolExtra(_extra);
+
+  try {
+    const result = await getLostBadgeResponse(
+      {
+        area: args.area ?? undefined,
+        locationUuids: args.locationUuids ?? undefined,
+        deviceUuids: args.deviceUuids ?? undefined,
+        afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
+        beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        faceWindowSeconds: args.faceWindowSeconds ?? undefined,
+        limit: args.limit ?? undefined,
+      },
+      args.timeZone ?? "UTC",
+      requestModifiers,
+      sessionId
+    );
+    return createToolStructuredContent<OUTPUT_SCHEMA>(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return createToolStructuredContent<OUTPUT_SCHEMA>({ error: message });
+  }
+};
+
+export function createTool(server: McpServer) {
+  server.registerTool(
+    TOOL_NAME,
+    {
+      description: TOOL_DESCRIPTION,
+      inputSchema: TOOL_ARGS,
+      outputSchema: OUTPUT_SCHEMA.shape,
+    },
+    TOOL_HANDLER
+  );
+}

--- a/src/types/access-anomaly-tool-types.ts
+++ b/src/types/access-anomaly-tool-types.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+import { createUuidSchema } from "../types.js";
+import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
+
+export const ANOMALY_RULES = [
+  "lost_or_inactive_badge",
+  "entry_not_made",
+  "off_hours",
+  "impossible_travel",
+  "area_novelty",
+] as const;
+
+export const TOOL_ARGS = {
+  area: z.string().nullable().describe("Optional: restrict analysis to events entering this area (full-text)."),
+  locationUuids: z
+    .array(createUuidSchema())
+    .nullable()
+    .describe("Optional: restrict to these Rhombus location UUIDs."),
+  deviceUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these camera UUIDs."),
+  startTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("Start of the window to analyze (inclusive). " + ISOTimestampFormatDescription),
+  endTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("End of the window to analyze (inclusive). " + ISOTimestampFormatDescription),
+  rules: z
+    .array(z.enum(ANOMALY_RULES))
+    .nullable()
+    .describe(
+      "Which rules to run; default all. Options: lost_or_inactive_badge, entry_not_made, off_hours, impossible_travel, area_novelty."
+    ),
+  baselineDays: z
+    .number()
+    .nullable()
+    .describe("Days of prior history used to learn each person's normal areas for area_novelty (default 30; 0 disables it)."),
+  offHoursStartHour: z
+    .number()
+    .nullable()
+    .describe("Local business-hours start hour 0–23; entries before it are off-hours (default 7)."),
+  offHoursEndHour: z
+    .number()
+    .nullable()
+    .describe("Local business-hours end hour 0–23; entries at/after it are off-hours (default 19)."),
+  impossibleTravelMaxSeconds: z
+    .number()
+    .nullable()
+    .describe("Max seconds between two different-area taps by one person to flag impossible travel (default 30)."),
+  limit: z.number().nullable().describe("Max events to analyze in the window (default 500)."),
+  timeZone: z
+    .string()
+    .nullable()
+    .describe("IANA timezone for hour-of-day checks and formatting, e.g. America/New_York. Defaults to UTC."),
+};
+
+const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
+export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
+
+const ClipHintSchema = z.object({ deviceUuid: z.string(), startTimeMs: z.number(), endTimeMs: z.number() });
+const StillHintSchema = z.object({ deviceUuid: z.string(), timestampMs: z.number() });
+
+export const AnomalyFindingSchema = z.object({
+  cardholderName: z.string().optional(),
+  rule: z.string().describe("Which rule fired."),
+  severity: z.string().describe('"high" or "medium".'),
+  datetime: z.string().optional(),
+  timestampMs: z.number().optional(),
+  deviceUuid: z.string().optional().describe("Camera at the event. Pass to camera-tool (image) / clips-tool (createClip)."),
+  area: z.string().optional(),
+  rationale: z.string().describe("Plain-language explanation of why this was flagged."),
+  clipHint: ClipHintSchema.optional(),
+  stillHint: StillHintSchema.optional(),
+});
+
+export const OUTPUT_SCHEMA = z.object({
+  findings: z
+    .array(AnomalyFindingSchema)
+    .optional()
+    .describe("Anomalies, ranked high severity first then most-recent."),
+  eventsAnalyzed: z.number().optional(),
+  error: z.string().optional(),
+});
+export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;

--- a/src/types/badge-timeline-tool-types.ts
+++ b/src/types/badge-timeline-tool-types.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import { createUuidSchema } from "../types.js";
+import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
+
+export const TOOL_ARGS = {
+  cardholderQuery: z
+    .string()
+    .describe('The cardholder (person) to reconstruct, full-text name match, e.g. "Eve" or "Eve Adams".'),
+  locationUuids: z
+    .array(createUuidSchema())
+    .nullable()
+    .describe("Optional: restrict to these Rhombus location UUIDs. Use the location-tool to resolve names."),
+  startTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("Start of the window (inclusive). " + ISOTimestampFormatDescription),
+  endTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("End of the window (inclusive). " + ISOTimestampFormatDescription),
+  clipPaddingSeconds: z
+    .number()
+    .nullable()
+    .describe("Seconds of video before/after each badge tap to include in the clip hint (default 15)."),
+  limit: z.number().nullable().describe("Maximum badge taps to include (default 200)."),
+  timeZone: z
+    .string()
+    .nullable()
+    .describe("IANA timezone used to format times, e.g. America/New_York. Defaults to UTC."),
+};
+
+const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
+export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
+
+const ClipHintSchema = z
+  .object({
+    deviceUuid: z.string(),
+    startTimeMs: z.number(),
+    endTimeMs: z.number(),
+  })
+  .describe("Pass to clips-tool createClip to get video of this tap.");
+
+const StillHintSchema = z
+  .object({
+    deviceUuid: z.string(),
+    timestampMs: z.number(),
+  })
+  .describe("Pass to camera-tool (requestType image) to get a still of this tap.");
+
+export const BadgeTimelineStopSchema = z.object({
+  timestampMs: z.number().optional(),
+  datetime: z.string().optional().describe("Human-readable tap time in the requested timezone."),
+  deviceUuid: z
+    .string()
+    .optional()
+    .describe("The camera at this door. Pass to camera-tool (image) or clips-tool (createClip)."),
+  area: z.string().optional().describe("The area entered (or exited) at this tap."),
+  label: z.string().optional(),
+  isAnomaly: z.boolean().optional().describe("True if this tap was an alerting/anomalous event."),
+  clipHint: ClipHintSchema.optional(),
+  stillHint: StillHintSchema.optional(),
+  gapToNextSeconds: z
+    .number()
+    .optional()
+    .describe("Seconds until the next tap — large gaps are unobserved movement between doors."),
+});
+
+export const OUTPUT_SCHEMA = z.object({
+  cardholderName: z.string().optional().describe("The resolved cardholder name."),
+  ambiguousCardholders: z
+    .array(z.string())
+    .optional()
+    .describe("Set when the query matched more than one person — disambiguate with the user before trusting the timeline."),
+  stops: z
+    .array(BadgeTimelineStopSchema)
+    .optional()
+    .describe("The cardholder's badge taps in chronological order (oldest first)."),
+  path: z.array(z.string()).optional().describe("Areas traversed, in order (consecutive repeats collapsed)."),
+  error: z.string().optional(),
+});
+export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;

--- a/src/types/lost-badge-tool-types.ts
+++ b/src/types/lost-badge-tool-types.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+import { createUuidSchema } from "../types.js";
+import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
+
+export const TOOL_ARGS = {
+  area: z.string().nullable().describe("Optional: restrict to events entering this area (full-text)."),
+  locationUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these location UUIDs."),
+  deviceUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these camera UUIDs."),
+  startTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("Start of the window to scan for lost/inactive-badge use (inclusive). " + ISOTimestampFormatDescription),
+  endTime: z
+    .string()
+    .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
+    .nullable()
+    .describe("End of the window (inclusive). " + ISOTimestampFormatDescription),
+  faceWindowSeconds: z
+    .number()
+    .nullable()
+    .describe("± seconds around each badge event to look for the face at the door (default 30)."),
+  limit: z.number().nullable().describe("Max badge events to scan in the window (default 50)."),
+  timeZone: z
+    .string()
+    .nullable()
+    .describe("IANA timezone for formatting times, e.g. America/New_York. Defaults to UTC."),
+};
+
+const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
+export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
+
+const ClipHintSchema = z.object({ deviceUuid: z.string(), startTimeMs: z.number(), endTimeMs: z.number() });
+const StillHintSchema = z.object({ deviceUuid: z.string(), timestampMs: z.number() });
+
+const FaceAtDoorSchema = z.object({
+  faceName: z.string().optional().describe('Recognized name, or absent/UNIDENTIFIED if no enrolled match.'),
+  personUuid: z.string().optional(),
+  thumbnailS3Key: z.string().optional().describe("Face crop thumbnail key for display."),
+  faceEventUuid: z.string().optional(),
+  eventTimestamp: z.string().optional(),
+});
+
+const SightingSchema = z.object({
+  deviceUuid: z.string().optional().describe("Camera where the same face was seen."),
+  datetime: z.string().optional(),
+  timestampMs: z.number().optional(),
+  similarity: z.number().optional(),
+  personUuid: z.string().optional(),
+});
+
+export const LostBadgeIncidentSchema = z.object({
+  cardholderOfRecord: z.string().optional().describe("The cardholder the badge is registered to (may not be who used it)."),
+  badgeStatus: z.string().optional(),
+  datetime: z.string().optional(),
+  timestampMs: z.number().optional(),
+  deviceUuid: z.string().optional().describe("Door camera. Pass to camera-tool (image) / clips-tool (createClip)."),
+  area: z.string().optional(),
+  clipHint: ClipHintSchema.optional(),
+  stillHint: StillHintSchema.optional(),
+  facesAtDoor: z.array(FaceAtDoorSchema).optional().describe("Face(s) captured at the door at the time of use."),
+  sightings: z
+    .array(SightingSchema)
+    .optional()
+    .describe("Same face seen across cameras, ordered in time — the track after the door."),
+  lastKnownSighting: z
+    .object({ deviceUuid: z.string().optional(), datetime: z.string().optional() })
+    .optional()
+    .describe("Most recent sighting — the person's last-known location."),
+});
+
+export const OUTPUT_SCHEMA = z.object({
+  incidents: z.array(LostBadgeIncidentSchema).optional(),
+  count: z.number().optional(),
+  error: z.string().optional(),
+});
+export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;


### PR DESCRIPTION
## What

Adds the OnGuard MIND tool suite to the MCP server, building on the existing OnGuard event search (#29):

- **F3 — follow-the-badge** (`badge-timeline-tool`): reconstructs one cardholder's movements as a chronological timeline with area path, per-stop gaps, and clip/still media hints.
- **F4 — access anomalies** (`access-anomaly-tool`): five deterministic rules over the window — lost/inactive badge, no-entry (tailgating), off-hours, impossible-travel, area-novelty — ranked, each with rationale + media hints.
- **F5 — lost/stolen-badge response** (`lost-badge-tool`): detects lost/inactive-badge use, returns the door clip/still, and (best-effort) the face at the door + a cross-camera track.
- Shared `badge-correlation` helper turning a badge event (camera + timestamp) into still/clip hints — reused by all three.
- **Fix:** `onguard-tool-api` reads the cardholder from the dedicated `cardholderName` field (dedicated-event-types put it there; `customDescription` is null on `ONGUARD_*` docs), with a legacy fallback.

## Validation

End-to-end against rhombus-dev-sandbox with the dedicated-types backend deployed — `validate.mjs` **20/20** (search, F3, F4, F5). Report: `rhombus-dev-sandbox/tests/lenels2-mind/READINESS.md`.

## Before merge — known gaps

- **No unit tests** for these tools yet; the existing vitest suite is broken (orphaned imports of deleted `camera-tool`/`automated-prompts-tool`). `validate.mjs` (E2E) is currently the only coverage.
- `cardholderName` is read via a cast because the generated `schema.ts` predates the field — regenerate `assets/openapi.json`/`schema.ts` once the backend OpenAPI exposes it, then drop the cast.
- Depends on the dedicated-types backend being released/deployed: event #72 (merged), webservice #1128 (merged), kconsumer producer (released 3.0.102); kconsumer bridge #101 still open.
- F5's face-track (face-at-door + cross-camera) is unvalidated — the sandbox has no FR data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
