### PR TITLE
docs(tools): query all 3 badge integrations (OnGuard/Elements/NetBox) for generic badge-in questions

### DIFF
--- a/src/tools-console/elements-tool.ts
+++ b/src/tools-console/elements-tool.ts
@@ -10,6 +10,14 @@ const TOOL_DESCRIPTION = `
 Searches Honeywell Elements (LenelS2 Elements) badge / access-control events for the organization. Use this to answer
 "who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday".
 
+NOTE: an organization may run any combination of Honeywell OnGuard (Lenel), Honeywell Elements (LenelS2
+Elements), and Lenel S2 NetBox badge integrations — each searched by its own sibling tool
+(onguard-events-tool / elements-events-tool / netbox-events-tool), all taking identical arguments and
+returning the same shape. For a general "who badged in / did anyone enter" question you usually do NOT
+know which integration recorded the event, so call ALL THREE sibling tools (in parallel) and combine the
+results — each returns an empty list when its integration isn't configured. Restrict to one vendor only
+when the user explicitly names it.
+
 Each returned event includes:
 - cardholderName: the person's name
 - deviceUuid: the camera that saw the event

--- a/src/tools-console/netbox-tool.ts
+++ b/src/tools-console/netbox-tool.ts
@@ -10,6 +10,14 @@ const TOOL_DESCRIPTION = `
 Searches Lenel S2 NetBox (Honeywell NetBox) badge / access-control events for the organization. Use this to answer
 "who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday".
 
+NOTE: an organization may run any combination of Honeywell OnGuard (Lenel), Honeywell Elements (LenelS2
+Elements), and Lenel S2 NetBox badge integrations — each searched by its own sibling tool
+(onguard-events-tool / elements-events-tool / netbox-events-tool), all taking identical arguments and
+returning the same shape. For a general "who badged in / did anyone enter" question you usually do NOT
+know which integration recorded the event, so call ALL THREE sibling tools (in parallel) and combine the
+results — each returns an empty list when its integration isn't configured. Restrict to one vendor only
+when the user explicitly names it.
+
 Each returned event includes:
 - cardholderName: the person's name
 - deviceUuid: the camera that saw the event

--- a/src/tools-console/onguard-tool.ts
+++ b/src/tools-console/onguard-tool.ts
@@ -10,6 +10,14 @@ const TOOL_DESCRIPTION = `
 Searches Honeywell OnGuard (Lenel) badge / access-control events for the organization. Use this to answer
 "who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday".
 
+NOTE: an organization may run any combination of Honeywell OnGuard (Lenel), Honeywell Elements (LenelS2
+Elements), and Lenel S2 NetBox badge integrations — each searched by its own sibling tool
+(onguard-events-tool / elements-events-tool / netbox-events-tool), all taking identical arguments and
+returning the same shape. For a general "who badged in / did anyone enter" question you usually do NOT
+know which integration recorded the event, so call ALL THREE sibling tools (in parallel) and combine the
+results — each returns an empty list when its integration isn't configured. Restrict to one vendor only
+when the user explicitly names it.
+
 Each returned event includes:
 - cardholderName: the person's name
 - deviceUuid: the camera that saw the event


### PR DESCRIPTION
## Why

The `onguard-events-tool` / `elements-events-tool` / `netbox-events-tool` are siblings that hit the same `searchIntegrationAccessEvents` backend with different `activityTypes`. Each description only described its own vendor, so for a vendor-agnostic question ("did anyone badge into X?") the model would pick one tool and miss events recorded by the others. In practice MIND answered "no badge-ins" for an org whose events were Elements.

## Change

Add a shared note to all three event-tool descriptions: an organization may run any combination of OnGuard / Elements / NetBox; for a general "who badged in / did anyone enter" question the model should call **all three** sibling tools in parallel and combine results (each returns an empty list when its integration isn't configured), and restrict to one vendor only when the user names it.

Description-only change. Companion to the chatbot PR that makes all three tools always-on.

Note: `test/tools/automated-prompts-tool.test.ts` fails to import on `main` (stale path `src/tools/` → `src/tools-console/`) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)