### PR TITLE
refactor(person-tracking): ground in access control + re-identification (not faces)

### DIFF
--- a/src/api/person-tracking-tool-api.ts
+++ b/src/api/person-tracking-tool-api.ts
@@ -1,179 +1,190 @@
 import { buildMediaHints } from "./badge-correlation.js";
-import { getFaceEvents, getRegisteredFaces, searchSimilarFaces } from "./faces-tool-api.js";
-import type { GetFaceEventsArgs, GetRegisteredFacesArgs } from "../types/faces-tools-types.js";
+import { searchElementsEvents } from "./elements-tool-api.js";
+import { getCameraList } from "./get-entity-tool-api.js";
+import { searchNetboxEvents } from "./netbox-tool-api.js";
+import { searchOnGuardEvents } from "./onguard-tool-api.js";
+import { listReidentificationEmbeddings, searchReidentificationMatchesByEmbedding } from "./reid-tool-api.js";
 import { formatTimestamp, type RequestModifiers } from "../util.js";
 
 export interface GetPersonTrackArgs {
-  personQuery?: string;
-  personUuid?: string;
-  faceEventUuid?: string;
-  locationUuids?: string[];
+  personQuery: string;
   afterMs?: number;
   beforeMs?: number;
+  locationUuids?: string[];
+  badgeMatchWindowSeconds?: number;
   clipPaddingSeconds?: number;
   limit?: number;
 }
 
-interface PersonRef {
-  name?: string;
-  personUuid?: string;
-}
+const DEFAULT_BADGE_MATCH_WINDOW_S = 30;
+const DEFAULT_TRACK_FORWARD_MS = 6 * 60 * 60 * 1000; // track 6h forward from the badge tap if no endTime
 
-/** A normalized face sighting before media hints are attached. */
-interface RawSighting {
-  deviceUuid?: string;
-  timestampMs?: number;
-  datetime?: string;
-  locationUuid?: string;
-  faceName?: string;
-  similarity?: number;
-  thumbnailS3Key?: string;
+/** RUUID without any `.vN` facet suffix, so a badge event's camera matches the camera-state list. */
+function stripFacet(uuid?: string): string {
+  return (uuid ?? "").split(".")[0];
 }
 
 /**
- * Fuzzy-match a free-text name against the registered-faces directory. Mirrors faces-tool's scoring
- * (4 = exact full name, 3 = first name, 2 = last name, 1 = substring ≥3 chars) but returns every person
- * tied at the best score so the caller can flag ambiguity instead of silently tracking the wrong person.
- */
-function matchRegisteredPeople(
-  query: string,
-  people: Array<{ name?: string | null; uuid?: string | null }>
-): PersonRef[] {
-  const input = query.toLowerCase().trim();
-  if (!input) return [];
-
-  let bestScore = 0;
-  const scored: Array<{ name: string; uuid: string; score: number }> = [];
-  for (const person of people) {
-    if (!person.name || !person.uuid) continue;
-    const fullName = person.name.toLowerCase().trim();
-    const parts = fullName.split(/\s+/);
-
-    let score = 0;
-    if (fullName === input) score = 4;
-    else if (parts[0] === input) score = 3;
-    else if (parts.length > 1 && parts[parts.length - 1] === input) score = 2;
-    else if (input.length >= 3 && fullName.includes(input)) score = 1;
-
-    if (score > 0) {
-      scored.push({ name: person.name, uuid: person.uuid, score });
-      if (score > bestScore) bestScore = score;
-    }
-  }
-
-  // Dedupe by uuid among the best-scoring tier.
-  const seen = new Set<string>();
-  const top: PersonRef[] = [];
-  for (const s of scored) {
-    if (s.score !== bestScore || seen.has(s.uuid)) continue;
-    seen.add(s.uuid);
-    top.push({ name: s.name, personUuid: s.uuid });
-  }
-  return top;
-}
-
-/**
- * Reconstructs one person's movements across cameras as a chronological track of face sightings, each
- * with the still/clip hints needed to show the moment. Pure orchestration over the face-recognition
- * APIs:
- *   - faceEventUuid  -> searchSimilarFaces (appearance match; works for unrecognized people)
- *   - personUuid     -> getFaceEvents filtered to that person
- *   - personQuery    -> resolve name against registered faces, then getFaceEvents
+ * Reconstructs where a named person went, grounded in access control + person re-identification:
+ *   1. find the person's badge tap(s) (OnGuard / Elements / NetBox) → a camera + time we KNOW is them,
+ *   2. pull the re-id embedding recorded on that camera nearest the badge time (the person at the door),
+ *   3. re-id-search that embedding across cameras over the window → their cross-camera movement track.
+ *
+ * Identity comes from the badge (not face recognition); the track is appearance/re-id based.
  */
 export async function getPersonTrack(
   args: GetPersonTrackArgs,
   timeZone: string,
   requestModifiers?: RequestModifiers,
   sessionId?: string
-): Promise<{
-  resolvedPerson?: PersonRef;
-  ambiguousPeople?: PersonRef[];
-  sightings: ReturnType<typeof buildSightings>;
-  path: string[];
-  lastKnownSighting?: ReturnType<typeof buildSightings>[number];
-  count: number;
-}> {
-  let resolvedPerson: PersonRef | undefined;
-  let raw: RawSighting[] = [];
+) {
+  // 1. Anchor on access-control events. Check all three badge integrations; an org may use any.
+  const badgeArgs = {
+    cardholderQuery: args.personQuery,
+    locationUuids: args.locationUuids,
+    afterMs: args.afterMs,
+    beforeMs: args.beforeMs,
+    limit: args.limit ?? 200,
+  };
+  const empty = { events: [] as Array<Record<string, unknown>> };
+  const [og, el, nb] = await Promise.all([
+    searchOnGuardEvents(badgeArgs, timeZone, requestModifiers, sessionId).catch(() => empty),
+    searchElementsEvents(badgeArgs, timeZone, requestModifiers, sessionId).catch(() => empty),
+    searchNetboxEvents(badgeArgs, timeZone, requestModifiers, sessionId).catch(() => empty),
+  ]);
+  type BadgeEvent = {
+    deviceUuid?: string;
+    timestampMs?: number;
+    datetime?: string;
+    cardholderName?: string;
+    areaEntering?: string;
+    areaExiting?: string;
+  };
+  const badgeEvents = [
+    ...(og.events as BadgeEvent[]).map((e) => ({ ...e, integration: "OnGuard" })),
+    ...(el.events as BadgeEvent[]).map((e) => ({ ...e, integration: "Elements" })),
+    ...(nb.events as BadgeEvent[]).map((e) => ({ ...e, integration: "NetBox" })),
+  ]
+    .filter((e) => e.deviceUuid && e.timestampMs != null)
+    .sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0));
 
-  if (args.faceEventUuid) {
-    // Appearance-based track from a seed sighting — handles people who aren't registered/named.
-    const similar = await searchSimilarFaces(args.faceEventUuid, timeZone, requestModifiers, sessionId);
-    raw = similar.map((s) => ({
-      deviceUuid: s.deviceUuid,
-      timestampMs: s.eventTimestampMs,
-      datetime: s.eventTimestamp,
-      similarity: s.similarity,
-      faceName: undefined,
-    }));
-  } else {
-    // Resolve to a person UUID (directly or by name) before pulling their face events.
-    let personUuid = args.personUuid;
-    if (!personUuid && args.personQuery) {
-      const peopleResponse = await getRegisteredFaces({} as GetRegisteredFacesArgs, requestModifiers, sessionId);
-      const matches = matchRegisteredPeople(args.personQuery, peopleResponse.people ?? []);
-      if (matches.length > 1) {
-        return { ambiguousPeople: matches, sightings: [], path: [], count: 0 };
-      }
-      if (matches.length === 0) {
-        return { sightings: [], path: [], count: 0 };
-      }
-      resolvedPerson = matches[0];
-      personUuid = matches[0].personUuid;
-    } else if (personUuid) {
-      resolvedPerson = { personUuid };
-    }
-
-    if (!personUuid) {
-      return { sightings: [], path: [], count: 0 };
-    }
-
-    const faceEventArgs: GetFaceEventsArgs = {
-      pageRequest: { maxPageSize: args.limit ?? 200, lastEvaluatedKey: null },
-      searchFilter: {
-        faceNameContains: null,
-        faceNames: [],
-        hasEmbedding: null,
-        hasName: null,
-        labels: [],
-        locationUuids: args.locationUuids ?? [],
-        personUuids: [personUuid],
-        timestampFilter:
-          args.afterMs != null || args.beforeMs != null
-            ? {
-                rangeStart: args.afterMs != null ? new Date(args.afterMs).toISOString() : null,
-                rangeEnd: args.beforeMs != null ? new Date(args.beforeMs).toISOString() : null,
-              }
-            : null,
-      },
+  if (badgeEvents.length === 0) {
+    return {
+      sightings: [],
+      path: [],
+      count: 0,
+      note: `No access-control (badge) events found for "${args.personQuery}" in the window — can't anchor a re-id track. Try a wider time range, or confirm the name as it appears on the badge.`,
     };
-    const { faceEvents } = await getFaceEvents(faceEventArgs, timeZone, requestModifiers, sessionId);
-    raw = faceEvents.map((e) => ({
-      deviceUuid: e.deviceUuid,
-      timestampMs: e.eventTimestampMs,
-      datetime: e.eventTimestamp,
-      locationUuid: e.locationUuid,
-      faceName: e.faceName,
-      thumbnailS3Key: e.thumbnailS3Key,
-    }));
-    if (!resolvedPerson?.name) {
-      const named = raw.find((r) => r.faceName);
-      if (named?.faceName) resolvedPerson = { name: named.faceName, personUuid };
-    }
   }
 
-  // Always enforce the time window client-side (searchSimilarFaces has no time filter, and the face-event
-  // time filter defaults to the last 7 days if unset) and order chronologically.
-  const ordered = raw
-    .filter((r) => r.timestampMs != null)
-    .filter((r) => (args.afterMs == null || (r.timestampMs as number) >= args.afterMs))
-    .filter((r) => (args.beforeMs == null || (r.timestampMs as number) <= args.beforeMs))
-    .sort((a, b) => (a.timestampMs ?? 0) - (b.timestampMs ?? 0))
-    .slice(0, args.limit ?? 200);
+  // Earliest badge tap in the window — track forward from there.
+  const anchor = badgeEvents[0];
+  const resolvedPerson = anchor.cardholderName ? { name: anchor.cardholderName } : undefined;
+  const anchorOut = {
+    deviceUuid: anchor.deviceUuid,
+    timestampMs: anchor.timestampMs,
+    datetime: anchor.datetime,
+    integration: anchor.integration,
+    area: anchor.areaEntering ?? anchor.areaExiting,
+  };
 
-  const sightings = buildSightings(ordered, timeZone, args.clipPaddingSeconds);
+  // 2. Resolve the badge camera's location (re-id list is scoped by location).
+  let anchorLocationUuid: string | undefined;
+  try {
+    const { cameras } = await getCameraList(requestModifiers, sessionId);
+    const dev = stripFacet(anchor.deviceUuid);
+    anchorLocationUuid = (cameras as Array<{ uuid?: string; locationUuid?: string }>).find(
+      (c) => stripFacet(c.uuid) === dev
+    )?.locationUuid;
+  } catch {
+    // best-effort; the re-id list can still run device-scoped without a location
+  }
 
-  // Camera sequence the person moved through, collapsing consecutive repeats.
+  // 3. Ground the re-id embedding: the person detected on that camera nearest the badge tap.
+  const winMs = (args.badgeMatchWindowSeconds ?? DEFAULT_BADGE_MATCH_WINDOW_S) * 1000;
+  const anchorMs = anchor.timestampMs as number;
+  const embeddings = await listReidentificationEmbeddings(
+    {
+      deviceUuids: [anchor.deviceUuid as string],
+      locationUuid: anchorLocationUuid,
+      startTimestampMs: anchorMs - winMs,
+      endTimestampMs: anchorMs + winMs,
+      limit: 100,
+    },
+    requestModifiers,
+    sessionId
+  );
+
+  if (embeddings.length === 0) {
+    return {
+      resolvedPerson,
+      anchor: anchorOut,
+      sightings: [],
+      path: [],
+      count: 0,
+      note: `Found ${anchor.cardholderName ?? "the person"}'s badge tap at ${anchor.datetime}, but no person re-identification embedding was recorded on that camera within ±${args.badgeMatchWindowSeconds ?? DEFAULT_BADGE_MATCH_WINDOW_S}s — can't build a re-id track. (Re-id needs human-detection coverage on the door camera.)`,
+    };
+  }
+
+  // The detection closest in time to the badge tap is the best proxy for the badge holder.
+  const seed = embeddings.reduce((best, e) =>
+    Math.abs((e.timestamp ?? 0) - anchorMs) < Math.abs((best.timestamp ?? 0) - anchorMs) ? e : best
+  );
+  if (!seed.embedding || seed.embedding.length === 0) {
+    return {
+      resolvedPerson,
+      anchor: anchorOut,
+      sightings: [],
+      path: [],
+      count: 0,
+      note: "The re-id detection at the door had no embedding vector; can't search for matches.",
+    };
+  }
+
+  // 4. Re-id search that appearance across cameras over the window.
+  const searchStart = args.afterMs ?? anchorMs;
+  const searchEnd = args.beforeMs ?? anchorMs + DEFAULT_TRACK_FORWARD_MS;
+  const matches = await searchReidentificationMatchesByEmbedding(
+    {
+      searchEmbedding: seed.embedding,
+      locationUuid: args.locationUuids?.[0],
+      startTimestampMs: searchStart,
+      endTimestampMs: searchEnd,
+      limit: args.limit ?? 200,
+    },
+    requestModifiers,
+    sessionId
+  );
+
+  // 5. Build the chronological track with media hints.
+  const ordered = matches
+    .filter((m) => m.timestamp != null)
+    .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+
+  const sightings = ordered.map((m, i) => {
+    const next = ordered[i + 1];
+    const gapToNextSeconds =
+      next?.timestamp != null && m.timestamp != null
+        ? Math.round((next.timestamp - m.timestamp) / 1000)
+        : undefined;
+    const { clipHint, stillHint } = buildMediaHints(
+      { deviceUuid: m.deviceUuid, timestampMs: m.timestamp },
+      args.clipPaddingSeconds
+    );
+    return {
+      timestampMs: m.timestamp,
+      datetime: m.timestamp != null ? formatTimestamp(m.timestamp, timeZone) : undefined,
+      deviceUuid: m.deviceUuid,
+      locationUuid: m.locationUuid,
+      distance: m.distance,
+      stableTrackId: m.stableTrackId,
+      thumbnailUri: m.thumbnailUri,
+      clipHint,
+      stillHint,
+      gapToNextSeconds,
+    };
+  });
+
   const path: string[] = [];
   for (const s of sightings) {
     if (s.deviceUuid && s.deviceUuid !== path[path.length - 1]) path.push(s.deviceUuid);
@@ -181,35 +192,10 @@ export async function getPersonTrack(
 
   return {
     resolvedPerson,
+    anchor: anchorOut,
     sightings,
     path,
     lastKnownSighting: sightings[sightings.length - 1],
     count: sightings.length,
   };
-}
-
-function buildSightings(ordered: RawSighting[], timeZone: string, clipPaddingSeconds?: number) {
-  return ordered.map((s, i) => {
-    const next = ordered[i + 1];
-    const gapToNextSeconds =
-      next?.timestampMs != null && s.timestampMs != null
-        ? Math.round((next.timestampMs - s.timestampMs) / 1000)
-        : undefined;
-    const { clipHint, stillHint } = buildMediaHints(
-      { deviceUuid: s.deviceUuid, timestampMs: s.timestampMs },
-      clipPaddingSeconds
-    );
-    return {
-      timestampMs: s.timestampMs,
-      datetime: s.datetime ?? (s.timestampMs != null ? formatTimestamp(s.timestampMs, timeZone) : undefined),
-      deviceUuid: s.deviceUuid,
-      locationUuid: s.locationUuid,
-      faceName: s.faceName,
-      similarity: s.similarity,
-      thumbnailS3Key: s.thumbnailS3Key,
-      clipHint,
-      stillHint,
-      gapToNextSeconds,
-    };
-  });
 }

--- a/src/api/reid-tool-api.ts
+++ b/src/api/reid-tool-api.ts
@@ -1,0 +1,102 @@
+import { postApi } from "../network/network.js";
+import type { schema } from "../types/schema.js";
+import type { RequestModifiers } from "../util.js";
+
+/** A person re-identification embedding (one human detection on one camera at one moment). */
+export interface ReidEmbedding {
+  deviceUuid?: string;
+  locationUuid?: string;
+  timestamp?: number;
+  embedding?: number[];
+  embeddingId?: string;
+  stableTrackId?: number;
+  thumbnailUri?: string;
+}
+
+function mapEmbedding(e: schema["GenericObjectEmbedding"]): ReidEmbedding {
+  return {
+    deviceUuid: e.deviceUuid ?? undefined,
+    locationUuid: e.locationUuid ?? undefined,
+    timestamp: e.timestamp ?? undefined,
+    embedding: (e.embedding ?? []).filter((n): n is number => n != null),
+    embeddingId: e.embeddingId ?? undefined,
+    stableTrackId: e.stableTrackId ?? undefined,
+    thumbnailUri: e.thumbnailUri ?? undefined,
+  };
+}
+
+/**
+ * Lists the person re-identification embeddings recorded on the given camera(s) in a time window —
+ * i.e. the people the camera's human-detection AI saw. Used to grab the embedding of the person standing
+ * at a door at a known moment (e.g. a badge tap), so it can be tracked across other cameras.
+ */
+export async function listReidentificationEmbeddings(
+  args: {
+    deviceUuids?: string[];
+    locationUuid?: string;
+    startTimestampMs?: number;
+    endTimestampMs?: number;
+    limit?: number;
+  },
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+): Promise<ReidEmbedding[]> {
+  const body: schema["Search_ListReidentificationEmbeddingsWSRequest"] = {
+    deviceUuids: args.deviceUuids,
+    locationUuid: args.locationUuid,
+    startTimestampMs: args.startTimestampMs,
+    endTimestampMs: args.endTimestampMs,
+    limit: args.limit ?? 100,
+  };
+  const res = await postApi<schema["Search_ListReidentificationEmbeddingsWSResponse"]>({
+    route: "/search/listReidentificationEmbeddings",
+    body,
+    modifiers: requestModifiers,
+    sessionId,
+  });
+  if (res.error) throw new Error(res.errorMsg ?? "listReidentificationEmbeddings failed");
+  return (res.embeddings ?? []).map(mapEmbedding);
+}
+
+/** One re-id match: an embedding sighting plus its distance to the search embedding (lower = closer). */
+export interface ReidMatch extends ReidEmbedding {
+  distance?: number;
+}
+
+/**
+ * Searches person re-identification matches for a given appearance embedding across cameras and time —
+ * "find this same person elsewhere". Returns sightings ordered by similarity (distance asc; lower is a
+ * closer match).
+ */
+export async function searchReidentificationMatchesByEmbedding(
+  args: {
+    searchEmbedding: number[];
+    deviceUuids?: string[];
+    locationUuid?: string;
+    startTimestampMs?: number;
+    endTimestampMs?: number;
+    limit?: number;
+  },
+  requestModifiers?: RequestModifiers,
+  sessionId?: string
+): Promise<ReidMatch[]> {
+  const body: schema["Search_SearchReidentificationMatchesByEmbeddingWSRequest"] = {
+    searchEmbedding: args.searchEmbedding,
+    deviceUuids: args.deviceUuids,
+    locationUuid: args.locationUuid,
+    startTimestampMs: args.startTimestampMs,
+    endTimestampMs: args.endTimestampMs,
+    limit: args.limit ?? 100,
+  };
+  const res = await postApi<schema["Search_SearchReidentificationMatchesByEmbeddingWSResponse"]>({
+    route: "/search/searchReidentificationMatchesByEmbedding",
+    body,
+    modifiers: requestModifiers,
+    sessionId,
+  });
+  if (res.error) throw new Error(res.errorMsg ?? "searchReidentificationMatchesByEmbedding failed");
+  return (res.matches ?? []).map((m) => ({
+    ...mapEmbedding(m.embedding ?? {}),
+    distance: m.distance ?? undefined,
+  }));
+}

--- a/src/tools-console/person-tracking-tool.ts
+++ b/src/tools-console/person-tracking-tool.ts
@@ -7,28 +7,25 @@ import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 const TOOL_NAME = "person-tracking-tool";
 
 const TOOL_DESCRIPTION = `
-Tracks one person's movements across cameras using face recognition. Use this for "track this person",
-"where did X go", "follow this person across the building", or "where was X last seen" — the camera-based
-counterpart to the badge-timeline tools (which follow door taps).
+Reconstructs where a named person went across cameras, e.g. "show me where Brandon Salzberg went" or
+"track Eve through the building yesterday". Identity is grounded in ACCESS CONTROL and the track uses
+person RE-IDENTIFICATION (appearance), NOT face recognition:
 
-Identify the person ONE of three ways (in priority order):
-- faceEventUuid: track by APPEARANCE from a specific sighting — works even for an unrecognized/unnamed
-  person (e.g. follow the person in this face event). Get a faceEventUuid from the faces-tool.
-- personUuid: the exact registered-person UUID (from faces-tool get-registered-faces).
-- personQuery: a full-text name (e.g. "Eve" or "Eve Adams"); it is resolved against the registered-faces
-  directory. If "ambiguousPeople" is returned the name matched more than one person — ask the user which
-  one before trusting the track.
+1. Finds the person's badge tap(s) (OnGuard / Elements / NetBox) in the window — a camera + time we KNOW
+   is them. (Pass the name as it appears on the badge.)
+2. Pulls the person re-id embedding recorded on that door camera nearest the badge tap (the person at the
+   door).
+3. Re-id-searches that appearance across all cameras over the window to reconstruct their movement.
 
-Returns the person's sightings in CHRONOLOGICAL order (oldest first), each with:
-- datetime / timestampMs, deviceUuid (the camera), and locationUuid
-- similarity (only on appearance/faceEventUuid tracks) and a face thumbnail key
-- clipHint (camera + start/end window) and stillHint (camera + timestamp)
-- gapToNextSeconds: time until the next sighting (a large gap = unobserved movement between cameras)
-plus a "path" array (the camera sequence, consecutive repeats collapsed) and "lastKnownSighting" (the
-person's last-known location).
+Returns:
+- resolvedPerson and "anchor" (the badge tap that grounded the track: door camera, time, integration).
+- sightings: chronological re-id hits, each with deviceUuid (camera), timestampMs/datetime, distance
+  (LOWER = closer appearance match), a thumbnail, clipHint/stillHint, and gapToNextSeconds.
+- path (camera sequence) and lastKnownSighting (last-known location).
+- note: set when no badge tap was found, or no re-id embedding existed on the door camera.
 
 Resolve relative times like "yesterday" to ISO 8601 first (use the timestamp tool), then pass
-startTime/endTime. Face tracking depends on face-recognition coverage, so treat the track as investigative.
+startTime/endTime. Re-id depends on human-detection coverage, so treat the track as investigative, not proof.
 
 IMPORTANT — to show the movement visually: for each sighting (or the key transitions), call the camera-tool
 (requestType "image", cameraUuid = sighting.deviceUuid, timestamp = sighting.timestampMs) for a still, and/or
@@ -42,12 +39,11 @@ const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   try {
     const result = await getPersonTrack(
       {
-        personQuery: args.personQuery ?? undefined,
-        personUuid: args.personUuid ?? undefined,
-        faceEventUuid: args.faceEventUuid ?? undefined,
-        locationUuids: args.locationUuids ?? undefined,
+        personQuery: args.personQuery,
         afterMs: args.startTime ? new Date(args.startTime).getTime() : undefined,
         beforeMs: args.endTime ? new Date(args.endTime).getTime() : undefined,
+        locationUuids: args.locationUuids ?? undefined,
+        badgeMatchWindowSeconds: args.badgeMatchWindowSeconds ?? undefined,
         clipPaddingSeconds: args.clipPaddingSeconds ?? undefined,
         limit: args.limit ?? undefined,
       },

--- a/src/types/person-tracking-tool-types.ts
+++ b/src/types/person-tracking-tool-types.ts
@@ -6,36 +6,29 @@ import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
 export const TOOL_ARGS = {
   personQuery: z
     .string()
-    .nullable()
     .describe(
-      'The recognized person to track, full-text name match against registered faces, e.g. "Eve" or "Eve Adams". ' +
-        "Provide this OR personUuid OR faceEventUuid."
+      'The person to track, full-text name match against their access-control (badge) records, e.g. "Brandon" or "Brandon Salzberg".'
     ),
-  personUuid: z
-    .string()
-    .nullable()
-    .describe("The exact person UUID to track (from faces-tool get-registered-faces). Takes precedence over personQuery."),
-  faceEventUuid: z
-    .string()
-    .nullable()
-    .describe(
-      "Track by appearance from a specific face sighting (a faceEvent UUID), even when the person isn't a registered/named face. " +
-        "Use this for 'track THIS person' from a sighting. Takes precedence over personQuery/personUuid."
-    ),
-  locationUuids: z
-    .array(createUuidSchema())
-    .nullable()
-    .describe("Optional: restrict to these Rhombus location UUIDs. Use the location-tool to resolve names."),
   startTime: z
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
     .nullable()
-    .describe("Start of the window (inclusive). " + ISOTimestampFormatDescription),
+    .describe("Start of the window to search badge taps and track over (inclusive). " + ISOTimestampFormatDescription),
   endTime: z
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
     .nullable()
     .describe("End of the window (inclusive). " + ISOTimestampFormatDescription),
+  locationUuids: z
+    .array(createUuidSchema())
+    .nullable()
+    .describe("Optional: restrict badge search and the re-id track to these Rhombus location UUIDs."),
+  badgeMatchWindowSeconds: z
+    .number()
+    .nullable()
+    .describe(
+      "± seconds around the badge tap to look on the door camera for the person's re-id embedding (default 30)."
+    ),
   clipPaddingSeconds: z
     .number()
     .nullable()
@@ -51,39 +44,24 @@ const TOOL_ARGS_SCHEMA = z.object(TOOL_ARGS);
 export type ToolArgs = z.infer<typeof TOOL_ARGS_SCHEMA>;
 
 const ClipHintSchema = z
-  .object({
-    deviceUuid: z.string(),
-    startTimeMs: z.number(),
-    endTimeMs: z.number(),
-  })
+  .object({ deviceUuid: z.string(), startTimeMs: z.number(), endTimeMs: z.number() })
   .describe("Pass to clips-tool createClip to get video of this sighting.");
 
 const StillHintSchema = z
-  .object({
-    deviceUuid: z.string(),
-    timestampMs: z.number(),
-  })
+  .object({ deviceUuid: z.string(), timestampMs: z.number() })
   .describe("Pass to camera-tool (requestType image) to get a still of this sighting.");
-
-const PersonRefSchema = z.object({
-  name: z.string().optional(),
-  personUuid: z.string().optional(),
-});
 
 export const SightingSchema = z.object({
   timestampMs: z.number().optional(),
   datetime: z.string().optional().describe("Human-readable sighting time in the requested timezone."),
-  deviceUuid: z
-    .string()
-    .optional()
-    .describe("The camera that saw the person. Pass to camera-tool (image) or clips-tool (createClip)."),
-  locationUuid: z.string().optional().describe("The location where the sighting occurred."),
-  faceName: z.string().optional().describe("The recognized name on this sighting, if any."),
-  similarity: z
+  deviceUuid: z.string().optional().describe("The camera that re-identified the person."),
+  locationUuid: z.string().optional(),
+  distance: z
     .number()
     .optional()
-    .describe("Appearance-match similarity (0-1) when tracking from a faceEventUuid seed."),
-  thumbnailS3Key: z.string().optional().describe("Thumbnail key for the detected face on this sighting."),
+    .describe("Re-id match distance to the door embedding — LOWER means a closer appearance match."),
+  stableTrackId: z.number().optional().describe("Per-camera track-consolidation id for this detection."),
+  thumbnailUri: z.string().optional().describe("Thumbnail of the detected person."),
   clipHint: ClipHintSchema.optional(),
   stillHint: StillHintSchema.optional(),
   gapToNextSeconds: z
@@ -92,22 +70,33 @@ export const SightingSchema = z.object({
     .describe("Seconds until the next sighting — large gaps mean the person was unobserved between cameras."),
 });
 
+const AnchorSchema = z
+  .object({
+    deviceUuid: z.string().optional().describe("The door camera where the badge tap happened."),
+    timestampMs: z.number().optional(),
+    datetime: z.string().optional(),
+    integration: z.string().optional().describe("Which badge system the tap came from (OnGuard / Elements / NetBox)."),
+    area: z.string().optional(),
+  })
+  .describe("The access-control badge tap used to ground the re-id track (the known identity moment).");
+
 export const OUTPUT_SCHEMA = z.object({
-  resolvedPerson: PersonRefSchema.optional().describe("The person actually tracked (name + UUID), when resolved."),
-  ambiguousPeople: z
-    .array(PersonRefSchema)
+  resolvedPerson: z
+    .object({ name: z.string().optional() })
     .optional()
-    .describe("Set when personQuery matched more than one registered person — disambiguate with the user before trusting the track."),
+    .describe("The person resolved from the badge record."),
+  anchor: AnchorSchema.optional(),
   sightings: z
     .array(SightingSchema)
     .optional()
-    .describe("The person's camera sightings in chronological order (oldest first)."),
+    .describe("Re-id sightings of the person across cameras, in chronological order (oldest first)."),
   path: z
     .array(z.string())
     .optional()
-    .describe("Camera UUIDs the person passed through, in order (consecutive repeats collapsed)."),
-  lastKnownSighting: SightingSchema.optional().describe("The most recent sighting — the person's last-known location."),
-  count: z.number().optional().describe("Number of sightings returned."),
+    .describe("Camera UUIDs the person was re-identified at, in order (consecutive repeats collapsed)."),
+  lastKnownSighting: SightingSchema.optional().describe("The most recent re-id sighting — last-known location."),
+  count: z.number().optional().describe("Number of re-id sightings returned."),
+  note: z.string().optional().describe("Set when the track couldn't be built (no badge tap, or no re-id at the door)."),
   error: z.string().optional(),
 });
 export type OUTPUT_SCHEMA = z.infer<typeof OUTPUT_SCHEMA>;

--- a/test/api/person-tracking-tool-api.test.ts
+++ b/test/api/person-tracking-tool-api.test.ts
@@ -1,96 +1,118 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import * as facesApi from "../../src/api/faces-tool-api.js";
+import * as onguard from "../../src/api/onguard-tool-api.js";
+import * as elements from "../../src/api/elements-tool-api.js";
+import * as netbox from "../../src/api/netbox-tool-api.js";
+import * as entity from "../../src/api/get-entity-tool-api.js";
+import * as reid from "../../src/api/reid-tool-api.js";
 import { getPersonTrack } from "../../src/api/person-tracking-tool-api.js";
 
-vi.mock("../../src/api/faces-tool-api.js");
+vi.mock("../../src/api/onguard-tool-api.js");
+vi.mock("../../src/api/elements-tool-api.js");
+vi.mock("../../src/api/netbox-tool-api.js");
+vi.mock("../../src/api/get-entity-tool-api.js");
+vi.mock("../../src/api/reid-tool-api.js");
 
 const TZ = "America/Los_Angeles";
 
-describe("getPersonTrack", () => {
-  beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  // default: no badge events anywhere unless a test overrides
+  vi.mocked(onguard.searchOnGuardEvents).mockResolvedValue({ events: [] } as never);
+  vi.mocked(elements.searchElementsEvents).mockResolvedValue({ events: [] } as never);
+  vi.mocked(netbox.searchNetboxEvents).mockResolvedValue({ events: [] } as never);
+  vi.mocked(entity.getCameraList).mockResolvedValue({ cameras: [] } as never);
+  vi.mocked(reid.listReidentificationEmbeddings).mockResolvedValue([] as never);
+  vi.mocked(reid.searchReidentificationMatchesByEmbedding).mockResolvedValue([] as never);
+});
 
-  it("tracks by personUuid: chronological order, collapsed path, gaps, hints, lastKnownSighting", async () => {
-    vi.mocked(facesApi.getFaceEvents).mockResolvedValue({
-      faceEvents: [
-        // intentionally out of order; two consecutive on camA should collapse in path
-        { deviceUuid: "camB", eventTimestampMs: 6000, eventTimestamp: "t3", faceName: "Eve Adams", locationUuid: "loc1", personUuid: "p1", thumbnailS3Key: "k3", uuid: "e3" },
-        { deviceUuid: "camA", eventTimestampMs: 1000, eventTimestamp: "t1", faceName: "Eve Adams", locationUuid: "loc1", personUuid: "p1", thumbnailS3Key: "k1", uuid: "e1" },
-        { deviceUuid: "camA", eventTimestampMs: 3000, eventTimestamp: "t2", faceName: "Eve Adams", locationUuid: "loc1", personUuid: "p1", thumbnailS3Key: "k2", uuid: "e2" },
-      ],
-      lastEvaluatedKey: undefined,
-    } as never);
-
-    const res = await getPersonTrack({ personUuid: "p1", clipPaddingSeconds: 10 }, TZ);
-
-    expect(res.count).toBe(3);
-    expect(res.sightings.map((s) => s.timestampMs)).toEqual([1000, 3000, 6000]);
-    expect(res.path).toEqual(["camA", "camB"]);
-    expect(res.sightings[0].gapToNextSeconds).toBe(2); // (3000-1000)/1000
-    expect(res.sightings[1].gapToNextSeconds).toBe(3); // (6000-3000)/1000
-    expect(res.sightings[2].gapToNextSeconds).toBeUndefined();
-    expect(res.sightings[0].clipHint).toEqual({ deviceUuid: "camA", startTimeMs: 1000 - 10000, endTimeMs: 1000 + 10000 });
-    expect(res.sightings[0].stillHint).toEqual({ deviceUuid: "camA", timestampMs: 1000 });
-    expect(res.lastKnownSighting?.deviceUuid).toBe("camB");
-    expect(res.resolvedPerson).toEqual({ name: "Eve Adams", personUuid: "p1" });
-  });
-
-  it("flags ambiguity when a name matches more than one registered person and does not track", async () => {
-    vi.mocked(facesApi.getRegisteredFaces).mockResolvedValue({
-      people: [
-        { name: "Eve Adams", uuid: "p1" },
-        { name: "Eve Brown", uuid: "p2" },
+describe("getPersonTrack (re-id grounded by access control)", () => {
+  it("badge tap -> door embedding (closest in time) -> re-id track across cameras", async () => {
+    vi.mocked(elements.searchElementsEvents).mockResolvedValue({
+      events: [
+        {
+          deviceUuid: "camDoor",
+          timestampMs: 1000,
+          datetime: "badge-time",
+          cardholderName: "Brandon Salzberg",
+          areaEntering: "Warehouse Entry",
+        },
       ],
     } as never);
-
-    const res = await getPersonTrack({ personQuery: "Eve" }, TZ);
-
-    expect(res.ambiguousPeople?.map((p) => p.personUuid).sort()).toEqual(["p1", "p2"]);
-    expect(res.count).toBe(0);
-    expect(res.sightings).toEqual([]);
-    expect(facesApi.getFaceEvents).not.toHaveBeenCalled();
-  });
-
-  it("resolves a unique name match then tracks that person", async () => {
-    vi.mocked(facesApi.getRegisteredFaces).mockResolvedValue({
-      people: [
-        { name: "Eve Adams", uuid: "p1" },
-        { name: "Bob Lee", uuid: "p2" },
-      ],
+    vi.mocked(entity.getCameraList).mockResolvedValue({
+      cameras: [{ uuid: "camDoor", locationUuid: "loc1" }],
     } as never);
-    vi.mocked(facesApi.getFaceEvents).mockResolvedValue({
-      faceEvents: [{ deviceUuid: "camA", eventTimestampMs: 1000, eventTimestamp: "t1", faceName: "Eve Adams", personUuid: "p1" }],
-      lastEvaluatedKey: undefined,
-    } as never);
-
-    const res = await getPersonTrack({ personQuery: "eve adams" }, TZ);
-
-    expect(res.resolvedPerson).toEqual({ name: "Eve Adams", personUuid: "p1" });
-    expect(res.count).toBe(1);
-    expect(vi.mocked(facesApi.getFaceEvents).mock.calls[0][0].searchFilter?.personUuids).toEqual(["p1"]);
-  });
-
-  it("tracks by appearance from a faceEventUuid seed, carrying similarity and honoring the time window", async () => {
-    vi.mocked(facesApi.searchSimilarFaces).mockResolvedValue([
-      { uuid: "s1", deviceUuid: "camA", personUuid: undefined, similarity: 0.92, eventTimestampMs: 1000, eventTimestamp: "t1" },
-      { uuid: "s2", deviceUuid: "camB", personUuid: undefined, similarity: 0.81, eventTimestampMs: 5000, eventTimestamp: "t2" },
-      { uuid: "s3", deviceUuid: "camC", personUuid: undefined, similarity: 0.77, eventTimestampMs: 9000, eventTimestamp: "t3" },
+    vi.mocked(reid.listReidentificationEmbeddings).mockResolvedValue([
+      { deviceUuid: "camDoor", timestamp: 5000, embedding: [0.9, 0.9], embeddingId: "far" },
+      { deviceUuid: "camDoor", timestamp: 1005, embedding: [0.1, 0.2], embeddingId: "near", stableTrackId: 7 },
+    ] as never);
+    vi.mocked(reid.searchReidentificationMatchesByEmbedding).mockResolvedValue([
+      { deviceUuid: "camHall", timestamp: 3000, distance: 0.1, thumbnailUri: "u2" },
+      { deviceUuid: "camDoor", timestamp: 1005, distance: 0.0, thumbnailUri: "u1" },
+      { deviceUuid: "camExit", timestamp: 6000, distance: 0.2, thumbnailUri: "u3" },
     ] as never);
 
-    // window excludes the 9000 sighting
-    const res = await getPersonTrack({ faceEventUuid: "seed", afterMs: 500, beforeMs: 6000 }, TZ);
+    const res = await getPersonTrack(
+      { personQuery: "Brandon", afterMs: 0, beforeMs: 10000, clipPaddingSeconds: 10 },
+      TZ
+    );
 
-    expect(res.count).toBe(2);
-    expect(res.sightings.map((s) => s.deviceUuid)).toEqual(["camA", "camB"]);
-    expect(res.sightings[0].similarity).toBe(0.92);
-    expect(facesApi.searchSimilarFaces).toHaveBeenCalledWith("seed", TZ, undefined, undefined);
+    // identity + anchor from the badge tap
+    expect(res.resolvedPerson).toEqual({ name: "Brandon Salzberg" });
+    expect(res.anchor).toMatchObject({ deviceUuid: "camDoor", integration: "Elements", area: "Warehouse Entry" });
+
+    // seeded the re-id search with the embedding CLOSEST in time to the badge tap (near, not far)
+    const seedArg = vi.mocked(reid.searchReidentificationMatchesByEmbedding).mock.calls[0][0];
+    expect(seedArg.searchEmbedding).toEqual([0.1, 0.2]);
+
+    // chronological track, collapsed path, last-known
+    expect(res.sightings.map((s) => s.timestampMs)).toEqual([1005, 3000, 6000]);
+    expect(res.path).toEqual(["camDoor", "camHall", "camExit"]);
+    expect(res.lastKnownSighting?.deviceUuid).toBe("camExit");
+    expect(res.sightings[0].clipHint).toEqual({ deviceUuid: "camDoor", startTimeMs: 1005 - 10000, endTimeMs: 1005 + 10000 });
+    expect(res.sightings[0].distance).toBe(0.0);
+    expect(res.count).toBe(3);
   });
 
-  it("returns empty (no error) when a name matches nobody", async () => {
-    vi.mocked(facesApi.getRegisteredFaces).mockResolvedValue({ people: [{ name: "Bob Lee", uuid: "p2" }] } as never);
-    const res = await getPersonTrack({ personQuery: "Zzz Nobody" }, TZ);
+  it("checks all three badge integrations and uses the earliest tap as the anchor", async () => {
+    vi.mocked(onguard.searchOnGuardEvents).mockResolvedValue({
+      events: [{ deviceUuid: "camA", timestampMs: 9000, datetime: "late", cardholderName: "X" }],
+    } as never);
+    vi.mocked(netbox.searchNetboxEvents).mockResolvedValue({
+      events: [{ deviceUuid: "camB", timestampMs: 2000, datetime: "early", cardholderName: "X" }],
+    } as never);
+    vi.mocked(reid.listReidentificationEmbeddings).mockResolvedValue([
+      { deviceUuid: "camB", timestamp: 2000, embedding: [0.5], embeddingId: "e" },
+    ] as never);
+
+    const res = await getPersonTrack({ personQuery: "X" }, TZ);
+
+    expect(onguard.searchOnGuardEvents).toHaveBeenCalled();
+    expect(elements.searchElementsEvents).toHaveBeenCalled();
+    expect(netbox.searchNetboxEvents).toHaveBeenCalled();
+    expect(res.anchor).toMatchObject({ deviceUuid: "camB", integration: "NetBox" }); // earliest (2000 < 9000)
+  });
+
+  it("returns a note (not an error) when the person has no badge taps in the window", async () => {
+    const res = await getPersonTrack({ personQuery: "Nobody", afterMs: 0, beforeMs: 100 }, TZ);
     expect(res.count).toBe(0);
-    expect(res.ambiguousPeople).toBeUndefined();
-    expect(res.resolvedPerson).toBeUndefined();
+    expect(res.sightings).toEqual([]);
+    expect(res.note).toMatch(/No access-control/i);
+    expect(reid.searchReidentificationMatchesByEmbedding).not.toHaveBeenCalled();
+  });
+
+  it("returns the anchor + a note when no re-id embedding exists on the door camera", async () => {
+    vi.mocked(onguard.searchOnGuardEvents).mockResolvedValue({
+      events: [{ deviceUuid: "camDoor", timestampMs: 1000, datetime: "t", cardholderName: "Brandon Salzberg" }],
+    } as never);
+    vi.mocked(entity.getCameraList).mockResolvedValue({ cameras: [{ uuid: "camDoor", locationUuid: "loc1" }] } as never);
+    vi.mocked(reid.listReidentificationEmbeddings).mockResolvedValue([] as never);
+
+    const res = await getPersonTrack({ personQuery: "Brandon" }, TZ);
+
+    expect(res.anchor).toMatchObject({ deviceUuid: "camDoor", integration: "OnGuard" });
+    expect(res.count).toBe(0);
+    expect(res.note).toMatch(/no person re-identification embedding/i);
+    expect(reid.searchReidentificationMatchesByEmbedding).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Reworks `person-tracking-tool` to the intended design: **identity from access control, movement from person re-identification** (appearance) — not face recognition (the v0.1.54 basis was wrong).

For "show me where Brandon Salzberg went":
1. Find the person's badge tap(s) (OnGuard / Elements / NetBox) in the window → a camera + time we KNOW is them (the `anchor`).
2. Pull the person re-id embedding recorded on that door camera nearest the badge tap (the person at the door).
3. Re-id-search that embedding across cameras over the window → chronological cross-camera sightings.

## How

New `src/api/reid-tool-api.ts` wraps the re-id endpoints (`/search/listReidentificationEmbeddings`, `/search/searchReidentificationMatchesByEmbedding`). Rewrote the tool's api/types/description/tests. Output: `resolvedPerson`, `anchor`, `sightings` (camera, time, `distance` = appearance closeness, thumbnail, clip/still hints, gap), `path`, `lastKnownSighting`, and a `note` when there's no badge tap or no re-id embedding at the door.

Supersedes the face-recognition implementation from v0.1.54 (PR #39).

## Tests
`test/api/person-tracking-tool-api.test.ts` — closest-embedding seeding, all-3-integrations + earliest anchor, no-badge note, no-embedding-at-door note. ✅ 4/4. Build clean.

## Note
Track only materializes if the door camera has person re-id / human-detection coverage with an embedding near the badge tap; otherwise returns the anchor + a clear note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)