### PR TITLE
Move tool details into input arguments schema

### DIFF
--- a/scripts/measure-tool-surface.ts
+++ b/scripts/measure-tool-surface.ts
@@ -1,0 +1,155 @@
+/**
+ * Measure the tool "description surface" this server contributes to an LLM's
+ * billed prefix.
+ *
+ * Why this exists: with OpenAI hosted `tool_search`, a deferred tool's PARAMETER
+ * SCHEMA is not billed but its NAME + DESCRIPTION always is (verified
+ * empirically — see PERF_MASTER_PLAN P2 #4a). So the description string is the
+ * only lever for deferred tools, and this script reports it per tool so we can
+ * see where the bytes are.
+ *
+ * Usage:
+ *   npx tsx scripts/measure-tool-surface.ts            # table, biggest first
+ *   npx tsx scripts/measure-tool-surface.ts --json     # machine output
+ *   npx tsx scripts/measure-tool-surface.ts --json > /tmp/before.json
+ *   npx tsx scripts/measure-tool-surface.ts --diff /tmp/before.json
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createFilteringProxy } from "../src/filtering-utils.js";
+
+type Captured = { name: string; description: string; paramDescChars: number };
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(HERE, "..", "src");
+
+function toolFiles(dir: string): string[] {
+	if (!fs.existsSync(dir)) return [];
+	return fs
+		.readdirSync(dir)
+		.filter((f) => f.endsWith(".ts") && f !== "getTools.ts")
+		.map((f) => path.join(dir, f));
+}
+
+/**
+ * Sum of every `.describe()` string reachable from an inputSchema shape.
+ * Zod 4 keeps descriptions in a global registry behind the `.description`
+ * getter (not on `_def`), and nests sub-schemas under `.def`.
+ */
+function paramDescriptionChars(inputSchema: unknown): number {
+	let total = 0;
+	const seen = new Set<unknown>();
+	const walk = (node: unknown, depth: number) => {
+		if (node === null || typeof node !== "object" || depth > 20) return;
+		if (seen.has(node)) return;
+		seen.add(node);
+		const zod = node as { def?: unknown; description?: unknown };
+		if (zod.def !== undefined && typeof zod.description === "string") {
+			total += zod.description.length;
+		}
+		const children = zod.def !== undefined ? [zod.def] : Object.values(node as object);
+		for (const value of children) {
+			if (typeof value === "function") continue;
+			if (value && typeof value === "object") {
+				for (const inner of Array.isArray(value) ? value : Object.values(value)) {
+					walk(inner, depth + 1);
+				}
+			}
+		}
+	};
+	for (const arg of Object.values((inputSchema ?? {}) as Record<string, unknown>)) {
+		walk(arg, 0);
+	}
+	return total;
+}
+
+async function collect(): Promise<Captured[]> {
+	const captured: Captured[] = [];
+	const stub = {
+		registerTool(name: string, config: Record<string, unknown>) {
+			captured.push({
+				name,
+				description: String(config.description ?? ""),
+				paramDescChars: paramDescriptionChars(config.inputSchema),
+			});
+		},
+		// Tools occasionally touch these during registration.
+		registerResource() {},
+		registerPrompt() {},
+		server: { setRequestHandler() {} },
+	};
+	// biome-ignore lint/suspicious/noExplicitAny: stub stands in for McpServer
+	const proxied = createFilteringProxy(stub as any);
+
+	const files = [
+		...toolFiles(path.join(SRC, "tools")),
+		...toolFiles(path.join(SRC, "tools-console")),
+		...toolFiles(path.join(SRC, "tools-partner")),
+	];
+	for (const file of files) {
+		const mod = (await import(pathToFileURL(file).href)) as {
+			createTool?: (server: unknown) => void | Promise<void>;
+		};
+		if (mod.createTool) await mod.createTool(proxied);
+	}
+	return captured;
+}
+
+/** Rough token estimate. Prose runs ~4 chars/token; good enough for targeting. */
+const tok = (chars: number) => Math.round(chars / 4);
+
+const args = process.argv.slice(2);
+const tools = (await collect()).sort(
+	(a, b) => b.description.length - a.description.length,
+);
+
+if (args.includes("--json")) {
+	console.log(
+		JSON.stringify(
+			{
+				tools: tools.map((t) => ({
+					name: t.name,
+					descChars: t.description.length,
+					paramDescChars: t.paramDescChars,
+				})),
+				totalDescChars: tools.reduce((s, t) => s + t.description.length, 0),
+			},
+			null,
+			2,
+		),
+	);
+} else {
+	const diffIdx = args.indexOf("--diff");
+	let before: Map<string, number> | undefined;
+	if (diffIdx >= 0) {
+		const prev = JSON.parse(fs.readFileSync(args[diffIdx + 1], "utf8")) as {
+			tools: { name: string; descChars: number }[];
+		};
+		before = new Map(prev.tools.map((t) => [t.name, t.descChars]));
+	}
+
+	console.log(
+		`${"tool".padEnd(36)} ${"desc chars".padStart(11)} ${"~tokens".padStart(8)} ${"param desc".padStart(11)}${before ? "  delta" : ""}`,
+	);
+	for (const t of tools) {
+		const delta = before
+			? `  ${(t.description.length - (before.get(t.name) ?? 0) >= 0 ? "+" : "") + (t.description.length - (before.get(t.name) ?? 0))}`
+			: "";
+		console.log(
+			`${t.name.padEnd(36)} ${String(t.description.length).padStart(11)} ${String(tok(t.description.length)).padStart(8)} ${String(t.paramDescChars).padStart(11)}${delta}`,
+		);
+	}
+	const total = tools.reduce((s, t) => s + t.description.length, 0);
+	const totalParam = tools.reduce((s, t) => s + t.paramDescChars, 0);
+	console.log(
+		`\n${tools.length} tools · descriptions ${total} chars (~${tok(total)} tokens, BILLED even when deferred)` +
+			`\n${" ".repeat(String(tools.length).length)}  param descriptions ${totalParam} chars (~${tok(totalParam)} tokens, unbilled until loaded)`,
+	);
+	if (before) {
+		const beforeTotal = [...before.values()].reduce((s, v) => s + v, 0);
+		console.log(
+			`  vs baseline: ${beforeTotal} -> ${total} chars (${(((total - beforeTotal) / beforeTotal) * 100).toFixed(1)}%)`,
+		);
+	}
+}

--- a/scripts/probe-served-catalog.ts
+++ b/scripts/probe-served-catalog.ts
@@ -1,0 +1,34 @@
+/**
+ * Connect to a running MCP server over streamable HTTP and report the tool
+ * catalog it actually serves (count + total description chars).
+ *
+ * Use this before any catalog-affecting eval run: a stale server holding the
+ * port silently serves the OLD catalog and turns the run into a null
+ * measurement (see PERF_MASTER_PLAN P2 #4a "harness gotcha").
+ *
+ *   npx tsx scripts/probe-served-catalog.ts http://localhost:3123/mcp
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const url = process.argv[2] ?? "http://localhost:3123/mcp";
+const apiKey = process.env.RHOMBUS_API_KEY ?? "";
+
+const transport = new StreamableHTTPClientTransport(new URL(url), {
+	requestInit: { headers: { "x-auth-apikey": apiKey } },
+});
+const client = new Client({ name: "catalog-probe", version: "1.0.0" });
+await client.connect(transport);
+
+const { tools } = await client.listTools();
+const total = tools.reduce((sum, t) => sum + (t.description?.length ?? 0), 0);
+const biggest = [...tools]
+	.sort((a, b) => (b.description?.length ?? 0) - (a.description?.length ?? 0))
+	.slice(0, 5)
+	.map((t) => `${t.name}=${t.description?.length ?? 0}`)
+	.join(", ");
+
+console.log(
+	`${url}\n  ${tools.length} tools · ${total} description chars (~${Math.round(total / 4)} tokens)\n  biggest: ${biggest}`,
+);
+await client.close();

--- a/src/tools-console/access-anomaly-tool.ts
+++ b/src/tools-console/access-anomaly-tool.ts
@@ -3,28 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getAccessAnomalies } from "../api/access-anomaly-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/access-anomaly-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildAccessAnomalyToolDescription } from "../types/access-anomaly-tool-types.js";
 
 const TOOL_NAME = "access-anomaly-tool";
 
-const TOOL_DESCRIPTION = `
-Scans Honeywell OnGuard (Lenel) access events over a time window and flags anomalous badge activity. Use for
-"find unusual badge activity", "anything suspicious in access this week", or proactive access review.
-
-Runs deterministic rules and returns ranked findings (high severity first):
-- lost_or_inactive_badge: a non-active badge (lost/suspended) was used
-- entry_not_made: access granted but no entry made (possible tailgating)
-- off_hours: entry outside business hours (configurable)
-- impossible_travel: one cardholder at two different areas seconds apart
-- area_novelty: a cardholder's first-ever entry to an area vs their prior history (needs a baseline window)
-
-Each finding includes cardholderName, the rule, severity, datetime, area, the camera deviceUuid, a plain-language
-rationale, and clip/still hints. Resolve relative times (e.g. "this week") to ISO 8601 first via time-tool.
-
-This is a triage aid: present findings grouped by severity, and for the notable ones call the camera-tool
-(requestType "image", cameraUuid = finding.deviceUuid, timestampISO = the finding's time as ISO 8601 — convert finding.timestampMs via time-conversion-tool) and/or clips-tool
-("createClip" using finding.clipHint) — in PARALLEL — so a human can confirm. Don't assert wrongdoing; surface the
-evidence.
-`;
+const TOOL_DESCRIPTION = buildAccessAnomalyToolDescription("Honeywell OnGuard (Lenel)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/badge-timeline-tool.ts
+++ b/src/tools-console/badge-timeline-tool.ts
@@ -3,30 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getBadgeTimeline } from "../api/badge-timeline-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/badge-timeline-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildBadgeTimelineToolDescription } from "../types/badge-timeline-tool-types.js";
 
 const TOOL_NAME = "badge-timeline-tool";
 
-const TOOL_DESCRIPTION = `
-Reconstructs one person's movements through a building from their Honeywell OnGuard (Lenel) badge taps.
-Use this for incident reconstruction / "follow the badge" requests, e.g. "reconstruct Eve's movements
-yesterday" or "where did this cardholder go".
-
-Returns the cardholder's badge taps in CHRONOLOGICAL order (oldest first), each with:
-- datetime / timestampMs and the area entered
-- deviceUuid: the camera at that door
-- clipHint (camera + start/end window) and stillHint (camera + timestamp)
-- gapToNextSeconds: time until the next tap (a large gap = unobserved movement between doors)
-plus a "path" array summarizing the areas traversed in order.
-
-Resolve relative times like "yesterday" to ISO 8601 first (use time-tool), then pass
-startTime/endTime. cardholderQuery is a full-text name match; if "ambiguousCardholders" is returned the
-query matched more than one person — ask the user which one before trusting the timeline.
-
-IMPORTANT — to show the movement visually: for each stop (or the key transitions), call the camera-tool
-(requestType "image", cameraUuid = stop.deviceUuid, timestampISO = the stop's time as ISO 8601 — convert stop.timestampMs via time-conversion-tool) for a still you can see,
-and/or the clips-tool (requestType "createClip", using stop.clipHint) for video. Issue those per-stop
-media calls in PARALLEL, then present the timeline as a chronological narrative.
-`;
+const TOOL_DESCRIPTION = buildBadgeTimelineToolDescription("Honeywell OnGuard (Lenel)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/camera-tool.ts
+++ b/src/tools-console/camera-tool.ts
@@ -6,65 +6,22 @@ import { extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "camera-tool";
 
+// Tool descriptions are billed on EVERY LLM call even while the tool is
+// deferred behind hosted tool_search, so this string carries only what the
+// model needs to CHOOSE this tool (including the triggers that MUST route
+// here). The step-by-step flows live on the requestType parameter description
+// — unbilled until the tool is loaded, and in front of the model exactly when
+// it is acting. See PERF_MASTER_PLAN P2 #4a.
 const TOOL_DESCRIPTION = `
-This tool can perform some action pertaining to the video stream of a camera. There are four types of requests
-that can be passed into "requestType":
-- image
-- get-settings
-- get-media-uris
-- get-ai-thresholds
+Acts on a camera's video stream. Set "requestType":
+- **image** — a frame from the camera at a given time (timestampISO defaults to ~5 minutes before now for a near-live view; pass a historical timestamp for a past moment, e.g. the time of a badge event). A high-resolution capture of what the camera saw — people, vehicles, license plates, any detectable object — for object recognition, anomaly detection, incident investigation, or situational assessment. Optional crop args zoom into a sub-region.
+- **get-settings** — current configuration of a camera or associated device (sensor, access controller): resolution, bitrate, image/exposure settings, storage. To CHANGE settings use **update-tool** instead.
+- **get-media-uris** — the camera's streaming/playback URIs (LAN and WAN live-stream and VOD URLs, e.g. H.264 and M3U8). Use when the user needs direct stream or playback endpoints.
+- **get-ai-thresholds** — the camera's AI detection threshold configuration (confidence thresholds for detection events). Use when diagnosing why a camera is or isn't generating AI events.
 
-What follows is a description of the behavior of this tool given the requestType "image"
-
-This tool should be used any time someone wants to specify a subset of cameras to use for a task, based on some features that the camera sees.  For example, interior cameras, cameras facing the street, cameras with a view of X, Y, Z, etc.
-
-For instance if someone says "I want X using cameras with Y" then this tool should get a snapshot of the image to answer the question of if the camera satisfies the Y predicate.
-
-This tool fetches a frame from a designated security camera at a given time (timestampISO — defaults to ~5 minutes
-before now for a near-live view; pass a historical timestamp to see a past moment, e.g. the time of a badge event).
-The image serves as a contextual input source for downstream tasks such as object recognition, anomaly detection,
-incident investigation, or situational assessment. When invoked, the tool provides the following:
-- Visual Scene Capture: A high-resolution image of what the camera observed at that time, including people, vehicles, license plates, and any detectable objects.
-- Optional zoom: pass cropX, cropY, cropWidth, cropHeight (each a percentage 0-100, origin at the top-left) to return only a sub-region of the frame so you can inspect a detail (e.g. a license plate or a doorway) more closely. Omit them for the full frame. When zooming into a small crop, pass a smaller downscaleFactor (e.g. 1-3) to preserve detail.
-
-What follows is a description of the behavior of this tool given the requestType "get-settings"
-
-This tool retrieves the current configuration for a specified camera or associated device (e.g., sensor, access controller). The returned JSON object can include detailed camera settings (e.g., resolution, bitrate) and various device-specific configurations (e.g. storage settings).
-
-By default (detail: "core") bulky geometry/table sub-configs (metering tables, ROI polygons, PTZ/motor config) are elided with an "<omitted...>" placeholder — everything you need to read or change image/video/exposure/storage settings is included. Pass detail: "full" only when the user asks about one of the elided areas.
-
-NOTE: To update camera settings, use the update-tool instead.
-
-What follows is a description of the behavior of this tool given the requestType "get-media-uris"
-
-Returns the camera's streaming/playback media URIs (LAN and WAN live-stream and VOD URLs, e.g. H.264 and M3U8 endpoints). Use when the user needs direct stream/playback endpoints for a camera.
-
-What follows is a description of the behavior of this tool given the requestType "get-ai-thresholds"
-
-Returns the camera's AI detection threshold configuration (e.g. confidence thresholds for detection events). Use when diagnosing why a camera is or isn't generating AI events.
-
----
-
-**AUTOMATIC SNAPSHOT FOR IMAGE QUALITY ISSUES** — When a user mentions camera image quality (darkness, brightness, blur, washed out, "doesn't look great", "fix the image", etc.), you MUST IMMEDIATELY:
-1. Call camera-tool with requestType "image" to capture a snapshot WITHOUT asking first.
-2. Analyze the image to identify quality issues.
-3. Call camera-tool with requestType "get-settings" to check current camera settings.
-4. Propose specific setting changes based on your analysis (store the exact values you plan to change, e.g. img_brightness, wdr_strength).
-5. When the user confirms ("yes", "confirm", "fix it", "apply", "go ahead", "ok", etc.), call update-tool with those stored settings — see update-tool's description for the confirmation flow. NEVER skip the update-tool call.
-
-Examples that REQUIRE the automatic snapshot flow:
-- "This camera's image doesn't look great"
-- "The image quality is poor"
-- "Can you fix the image"
-- "Adjust settings to be optimal"
-- "The camera looks blurry/dark/washed out"
-- Any mention of image appearance problems.
-
-**VISUAL-FEATURE CAMERA FILTERING** — When the user asks for cameras filtered by what they can see (indoors/outdoors, "facing the street", "with a view of X", parking lot, entrance), you MUST:
-1. First get the camera list via get-entity-tool or location-tool.
-2. Then call camera-tool with requestType "image" for EACH candidate camera (in PARALLEL).
-3. Analyze each image to determine if it meets the user's criteria.
-4. Return only the cameras that match.
+**This tool is REQUIRED, not optional, for two situations** (the exact steps are on the requestType parameter):
+1. **Camera image quality** — "doesn't look great", poor image quality, dark, bright, blurry, washed out, "fix the image", "adjust settings to be optimal", or any mention of image appearance problems: snapshot immediately without asking, then check settings, then propose changes.
+2. **Filtering cameras by what they see** — interior vs exterior, "facing the street", "with a view of X", parking lot, entrance, or any "I want X using cameras with Y": snapshot each candidate camera and judge the predicate from the images.
 `;
 
 const logger = getLogger("camera-tool");

--- a/src/tools-console/clips-tool.ts
+++ b/src/tools-console/clips-tool.ts
@@ -25,40 +25,9 @@ Retrieves saved video clips from the Rhombus system. Saved clips can be viewed f
 Clips are either manually saved by the user, or automatically by some defined policy. Therefore, this tool
 is not for looking up the events that have occured.
 
-This tool allows you to:
-* Get saved clips or clips expiring soon (filter by devices, locations, search string, time range).
-* Get all shared live video streams for the organization.
-* Get all timelapse clips for the organization.
-* Get clip groups ("clipGroups") and shared clip groups ("sharedClips") for the organization.
-* Create (save) a new clip from a camera's footage ("createClip") — requires spliceRequest with cameraUuid and startTimeMs/endTimeMs (epoch milliseconds). Use this to save video evidence around an event.
-* Delete a saved clip ("deleteClip") — requires clipUuid. This is destructive and irreversible; confirm with the user first.
+Set "requestType" to: get saved clips or clips expiring soon (filter by devices, locations, name search, and time range); list the org's shared live video streams, timelapse clips, clip groups, or shared clip groups; **createClip** to save a new clip from a camera's footage (video evidence around an event); or **deleteClip** to permanently delete a saved clip — destructive and irreversible, confirm with the user first.
 
-Filter options (for saved and expiringSoon only):
-* Specific devices using their UUIDs (deviceUuidFilters).
-* Specific locations using their UUIDs (locationUuidFilters).
-* A simple string search on clip names (searchFilter).
-* A time range: start (timestampISOAfter) and/or end (timestampISOBefore) timestamp in ISO 8601 format.
-
-The tool returns a JSON object with the following structure and important fields:
-* **errorMsg (string | null):** An error message if the request failed.
-* **objecterror (boolean | null):** Indicates if an object-level error occurred.
-* **pageToken (string | null):** A token to be supplied on the next search request to get the next page of results. If this token is null, there is no more data available.
-* **savedClips (array of objects | null):** An array where each object represents a saved video clip. Each clip object contains the following important fields:
-    * **uuid (string):** The unique identifier for the video clip.
-    * **title (string):** The name given to the video clip.
-    * **description (string | null):** An optional description for the clip.
-    * **timestampMs (int64):** The start time of the video clip in milliseconds since epoch.
-    * **createdAtMs (int64):** The creation timestamp of the clip in milliseconds since epoch.
-    * **createdAtTimestamp (string):** The creation timestamp of the clip in ISO 8601 format.
-    * **deviceUuid (string):** The UUID of the primary device (e.g., camera) that recorded the clip.
-    * **deviceUuids (array of strings or null):** A list of UUIDs for all devices associated with the clip.
-    * **durationSec (int32):** The length of the video clip in seconds.
-    * **status (string):** The current processing status of the clip, with possible values such as INITIATING, UPLOADING, RENDERING, FAILED, COMPLETE, OFFLINE, or UNKNOWN.
-    * **userUuid (string | null):** The UUID of the user associated with the clip, if applicable.
-    * **sourceAlertUuid (string | null):** The UUID of the alert that triggered the creation of this clip, if any.
-* **sharedLiveVideoStreams (array):** When requestType is sharedLiveStreams, list of shared live video stream objects.
-* **timelapseClips (array):** When requestType is timelapseClips, list of timelapse clip objects.
-
+Each saved clip carries uuid, title, description, start and creation timestamps, the recording device(s), durationSec, processing status (INITIATING / UPLOADING / RENDERING / FAILED / COMPLETE / OFFLINE / UNKNOWN), and the alert that triggered it when there was one. Results paginate via pageToken (null when there is no more data).
 `;
 
 const TOOL_HANDLER = async (args: ToolArgs, extra: unknown) => {

--- a/src/tools-console/elements-access-anomaly-tool.ts
+++ b/src/tools-console/elements-access-anomaly-tool.ts
@@ -3,28 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getElementsAccessAnomalies } from "../api/elements-access-anomaly-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/elements-access-anomaly-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildAccessAnomalyToolDescription } from "../types/access-anomaly-tool-types.js";
 
 const TOOL_NAME = "elements-access-anomaly-tool";
 
-const TOOL_DESCRIPTION = `
-Scans Honeywell Elements (LenelS2 Elements) access events over a time window and flags anomalous badge activity. Use for
-"find unusual badge activity", "anything suspicious in access this week", or proactive access review.
-
-Runs deterministic rules and returns ranked findings (high severity first):
-- lost_or_inactive_badge: a non-active badge (lost/suspended) was used
-- entry_not_made: access granted but no entry made (possible tailgating)
-- off_hours: entry outside business hours (configurable)
-- impossible_travel: one cardholder at two different areas seconds apart
-- area_novelty: a cardholder's first-ever entry to an area vs their prior history (needs a baseline window)
-
-Each finding includes cardholderName, the rule, severity, datetime, area, the camera deviceUuid, a plain-language
-rationale, and clip/still hints. Resolve relative times (e.g. "this week") to ISO 8601 first via time-tool.
-
-This is a triage aid: present findings grouped by severity, and for the notable ones call the camera-tool
-(requestType "image", cameraUuid = finding.deviceUuid, timestampISO = the finding's time as ISO 8601 — convert finding.timestampMs via time-conversion-tool) and/or clips-tool
-("createClip" using finding.clipHint) — in PARALLEL — so a human can confirm. Don't assert wrongdoing; surface the
-evidence.
-`;
+const TOOL_DESCRIPTION = buildAccessAnomalyToolDescription("Honeywell Elements (LenelS2 Elements)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/elements-badge-timeline-tool.ts
+++ b/src/tools-console/elements-badge-timeline-tool.ts
@@ -3,30 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getElementsBadgeTimeline } from "../api/elements-badge-timeline-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/elements-badge-timeline-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildBadgeTimelineToolDescription } from "../types/badge-timeline-tool-types.js";
 
 const TOOL_NAME = "elements-badge-timeline-tool";
 
-const TOOL_DESCRIPTION = `
-Reconstructs one person's movements through a building from their Honeywell Elements (LenelS2 Elements) badge taps.
-Use this for incident reconstruction / "follow the badge" requests, e.g. "reconstruct Eve's movements
-yesterday" or "where did this cardholder go".
-
-Returns the cardholder's badge taps in CHRONOLOGICAL order (oldest first), each with:
-- datetime / timestampMs and the area entered
-- deviceUuid: the camera at that door
-- clipHint (camera + start/end window) and stillHint (camera + timestamp)
-- gapToNextSeconds: time until the next tap (a large gap = unobserved movement between doors)
-plus a "path" array summarizing the areas traversed in order.
-
-Resolve relative times like "yesterday" to ISO 8601 first (use time-tool), then pass
-startTime/endTime. cardholderQuery is a full-text name match; if "ambiguousCardholders" is returned the
-query matched more than one person — ask the user which one before trusting the timeline.
-
-IMPORTANT — to show the movement visually: for each stop (or the key transitions), call the camera-tool
-(requestType "image", cameraUuid = stop.deviceUuid, timestampISO = the stop's time as ISO 8601 — convert stop.timestampMs via time-conversion-tool) for a still you can see,
-and/or the clips-tool (requestType "createClip", using stop.clipHint) for video. Issue those per-stop
-media calls in PARALLEL, then present the timeline as a chronological narrative.
-`;
+const TOOL_DESCRIPTION = buildBadgeTimelineToolDescription("Honeywell Elements (LenelS2 Elements)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/elements-lost-badge-tool.ts
+++ b/src/tools-console/elements-lost-badge-tool.ts
@@ -3,26 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getElementsLostBadgeResponse } from "../api/elements-lost-badge-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/elements-lost-badge-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildLostBadgeToolDescription } from "../types/lost-badge-tool-types.js";
 
 const TOOL_NAME = "elements-lost-badge-tool";
 
-const TOOL_DESCRIPTION = `
-Lost / stolen-badge live response for Honeywell Elements (LenelS2 Elements) access. Use for "a lost badge was just used —
-who is it and where did they go?", or to review lost/inactive-badge use over a window.
-
-For each lost/inactive-badge use it returns:
-- cardholderOfRecord (who the badge belongs to — may NOT be who used it) and badgeStatus
-- the door deviceUuid + time, plus clipHint / stillHint for the door footage
-- facesAtDoor: the face(s) captured at the door at that moment — a recognized name, or UNIDENTIFIED (an unknown
-  face on a valid badge is the strongest stolen/shared-badge signal), with a thumbnail
-- sightings: that same face tracked across cameras, ordered in time, ending in lastKnownSighting (last-known location)
-
-Resolve relative times (e.g. "in the last hour") to ISO 8601 first via time-tool.
-
-To present: show the door still/clip (camera-tool image / clips-tool createClip with the hints), the face at the
-door, and the cross-camera track to last-known location. Detection + door evidence are reliable; the face track
-depends on face-recognition coverage, so treat it as investigative, not proof.
-`;
+const TOOL_DESCRIPTION = buildLostBadgeToolDescription("Honeywell Elements (LenelS2 Elements)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/elements-tool.ts
+++ b/src/tools-console/elements-tool.ts
@@ -7,7 +7,7 @@ import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "elements-events-tool";
 
-const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Honeywell Elements (LenelS2 Elements)");
+const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Honeywell Elements (LenelS2 Elements)", "Elements");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/elements-tool.ts
+++ b/src/tools-console/elements-tool.ts
@@ -2,42 +2,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { searchElementsEvents } from "../api/elements-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/elements-tool-types.js";
+import { buildBadgeEventsToolDescription } from "../types/onguard-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "elements-events-tool";
 
-const TOOL_DESCRIPTION = `
-Searches Honeywell Elements (LenelS2 Elements) badge / access-control events for the organization. Use this to answer
-"who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday".
-
-NOTE: an organization may run any combination of Honeywell OnGuard (Lenel), Honeywell Elements (LenelS2
-Elements), and Lenel S2 NetBox badge integrations — each searched by its own sibling tool
-(onguard-events-tool / elements-events-tool / netbox-events-tool), all taking identical arguments and
-returning the same shape. For a general "who badged in / did anyone enter" question you usually do NOT
-know which integration recorded the event, so call ALL THREE sibling tools (in parallel) and combine the
-results — each returns an empty list when its integration isn't configured. Restrict to one vendor only
-when the user explicitly names it. Badge events may ALSO exist outside these three vendors: native
-Rhombus ACU doors and Brivo doors are searched via events-tool (eventType "access-control" /
-"brivo-access-control") — a deferred tool; discover it via tool search and include it for generic
-"who badged in" questions.
-
-Each returned event includes:
-- cardholderName: the person's name
-- deviceUuid: the camera that saw the event
-- timestampMs / datetime: when it happened
-- label: e.g. "Elements: Badge Authorized" (a grant) or an anomaly label
-- badgeStatus, badgeType, areaEntering, areaExiting, entryMade, isAnomaly
-
-Filters (all optional): area, locationUuids, deviceUuids, cardholderQuery, badgeStatus, badgeType,
-anomalyOnly, entryMade, startTime, endTime, limit. Resolve relative times like "yesterday" to ISO 8601
-first (use time-tool), then pass startTime/endTime.
-
-IMPORTANT — to show pictures and video of each person so the user can visually identify them: after this
-returns, for each event (or the most relevant ones) call the camera-tool (requestType "image",
-cameraUuid = the event's deviceUuid, timestampISO = the event's time as ISO 8601 — convert its timestampMs via time-conversion-tool) to get a still you can see, and/or the
-clips-tool (requestType "createClip") with a short window around the timestamp for video. Issue those
-per-event media calls in PARALLEL.
-`;
+const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Honeywell Elements (LenelS2 Elements)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/events-tool.ts
+++ b/src/tools-console/events-tool.ts
@@ -26,109 +26,21 @@ const logger = getLogger("events-tool");
 const TOOL_NAME = "events-tool";
 
 // "faces" | "people" | "human" | "access-control"
+//
+// Tool descriptions are billed on EVERY LLM call even while the tool is
+// deferred behind hosted tool_search, so this string carries only what the
+// model needs to CHOOSE this tool. Per-mode arguments, field semantics, and
+// enum catalogs live on the input-parameter descriptions (unbilled until the
+// tool is loaded, still in front of the model when it builds the call).
+// See PERF_MASTER_PLAN P2 #4a.
 const TOOL_DESCRIPTION = `
-**Scope:** This tool returns **raw, event-level data** (individual events with timestamps). Use **report-tool** when you need aggregated counts, time-series summaries, or analytics over intervals.
+**Raw, event-level records** — individual events, each with a timestamp. Modes are set by "eventType": access-control, brivo-access-control, environmental-gateway, climate-sensor, component-events, camera, button-press, occupancy, proximity, doorbell.
 
-**Vehicles vs lpr-tool:** **eventType "camera"** returns **footage seekpoints** from that camera's recording timeline—**every activity type** the API returns for the window (human motion, vehicle motion, and others depending on the camera and analytics). Some rows may include plate or vehicle metadata on the seekpoint. **lpr-tool** is still the right choice for **org LPR workflows**: saved vehicles, vehicle labels, fuzzy plate search, and vehicle event APIs—not a replacement for "everything this camera logged on its timeline."
+Use it when the user asks for specific events: unlocks, badge ins, credentials, arrivals, Brivo access control, door state changes, panic or doorbell button presses, environmental gateway readings, climate data (temperature, humidity, air quality, vape), occupancy counts, proximity tags, or a camera's timeline activity. For maximum flexibility across event types at a location, use eventType "component-events".
 
-This tool has multiple modes, set by "eventType": access-control, brivo-access-control, environmental-gateway, climate-sensor, component-events, camera. Use it when the user asks for specific events (unlocks, badge ins, credentials, arrivals, environmental readings, climate data, camera timeline activity, or other component events). It can return large result sets; keep time ranges narrow. For ranges spanning more than ~24 hours, prefer report-tool for aggregates. For maximum flexibility across event types at a location, use eventType "component-events".
+**Not this tool:** use **report-tool** for aggregated counts, time-series summaries, or analytics over intervals — including any range spanning more than ~24 hours. Use **lpr-tool** for org LPR workflows: saved vehicles, vehicle labels, fuzzy plate search, and vehicle event APIs. eventType "camera" returns that camera's own **footage seekpoints** — **every activity type** on its recording timeline (human motion, vehicle motion, and others depending on camera and analytics), sometimes carrying plate or vehicle metadata — which is not a replacement for lpr-tool's plate search.
 
----
-
-When eventType is "brivo-access-control":
-
-Retrieves badge/credential events from Brivo-integrated doors. Automatically fetches the Brivo integration configuration to determine which locations have Brivo doors mapped. No door UUIDs are required.
-
-Use this when the user asks specifically about Brivo events, Brivo badge ins, Brivo access control, or events from Brivo doors.
-
-Arguments:
-  * **startTime (string):** Start of the time range (ISO 8601).
-  * **endTime (string):** End of the time range (ISO 8601).
-
-Returns:
-  * **integrationEnabled:** Whether the Brivo integration is currently enabled.
-  * **brivoDoorsConfigured:** Number of Brivo doors configured in the integration.
-  * **brivoDoors:** List of Brivo doors with their IDs, names, and associated Rhombus location UUIDs.
-  * **events:** Credential received events from all locations that have Brivo doors configured, sorted newest first.
-
-Note: Events are fetched at the location level, so results may include events from all access-controlled doors at locations where Brivo is configured.
-
----
-
-When eventType is "access-control":
-
-Retrieves access control events (arrivals, badge ins, credentials, unlocks) for the given door(s). Can return a lot of data—use a narrow time range.
-
-Arguments:
-  * **accessControlledDoorUuids (array of strings):** UUIDs of the access-controlled doors.
-  * **startTime (string):** Start of the time range (ISO 8601).
-  * **endTime (string):** End of the time range (ISO 8601).
-
-The \`credSource\` field indicates how the event was triggered:
-  * **REMOTE:** Rhombus Key app remote unlock.
-  * **REMOTE (Admin):** Unlock via Rhombus console or browser/mobile app.
-  * **BLE_WAVE:** User waved hand over the reader.
-  * **NFC:** User tapped badge or phone on the reader.
-
----
-
-Retrieves environmental gateway events (sensor readings, derived values) for a device in a time range. Timestamps are in the **device** timezone, not necessarily UTC.
-
-Arguments:
-  * **deviceUuid (string):** UUID of the environmental gateway device.
-  * **startTime (string):** Start of range (ISO 8601).
-  * **endTime (string):** End of range (ISO 8601).
-
----
-
-When eventType is "climate-sensor":
-
-Retrieves climate sensor events (temperature, humidity, air quality, etc.) for a sensor in a time range. Timestamps are in the **sensor** timezone, not necessarily UTC.
-
-Arguments:
-  * **sensorUuid (string):** UUID of the climate sensor.
-  * **startTime (string):** Start of range (ISO 8601).
-  * **endTime (string):** End of range (ISO 8601).
-  * **limit (number, optional):** Max events to return. Default 1000.
-
----
-
-When eventType is "component-events":
-
-Retrieves all component event types for a location in a time range. Most flexible option; filter by event type via componentEventTypes. Timestamps are in the **location** timezone, not necessarily UTC.
-
-Arguments:
-  * **locationUuid (string):** UUID of the location.
-  * **componentEventTypes (array, optional):** Event types to include. If empty or omitted, returns all types.
-  * **startTime (string):** Start of range (ISO 8601).
-  * **endTime (string):** End of range (ISO 8601).
-
-Valid event types include:
-  * **DoorbellEvent:** Doorbell button press events
-  * **CredentialReceivedEvent:** Badge/credential scans (NFC, BLE_WAVE, REMOTE unlocks)
-  * **DoorStateChangeEvent:** Door state changes (locked/unlocked)
-  * **ButtonEvent:** Generic button press events
-  * **PanicButtonEvent:** Panic/emergency button activations
-  * **DoorReaderStateChangeEvent:** Changes in door reader state
-  * **DoorRelayStateChangeEvent:** Changes in door relay state
-  * **AccessControlUnitTamperEvent:** Tamper detection events
-  * **AccessControlUnitBatteryStateChangeEvent:** Battery state changes
-  * **WaveToUnlockIntentExpiredEvent:** Wave-to-unlock timeout events
-  * **DoorAuthFirstInStateEvent:** First-in authentication state events
-  * **DoorScheduleFirstInStateEvent:** First-in schedule state events
-  * And more (see input schema for full list).
-
----
-
-When eventType is "camera":
-
-Retrieves **footage seekpoints** for one camera: **all activity types** returned for the search window (not limited to human motion). Each item includes an **activity** string plus **timestamp**; plate/vehicle/face fields appear when the API provides them. Use **lpr-tool** for org LPR saved vehicles, labels, and dedicated plate search.
-
-Arguments:
-  * **cameraUuid (string):** UUID of the camera.
-  * **startTime (string):** Start of range (ISO 8601).
-  * **duration (number):** Search window in seconds. Default 3600 (1 hour).
-
+Result sets can be large: keep time ranges narrow. Per-mode required arguments, field semantics, and the full component-event-type list are documented on the input parameters.
 `;
 
 const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {

--- a/src/tools-console/faces-tool.ts
+++ b/src/tools-console/faces-tool.ts
@@ -53,29 +53,13 @@ function resolveNamesToRegisteredFaces(
 }
 
 const TOOL_DESCRIPTION = `
-This tool interacts with the Rhombus face recognition system to retrieve information about face sightings and registered faces.
+Rhombus **face recognition**: face sightings and registered faces. Use it to identify *who* was seen (unique individuals by name) — "who was in the office", "who was seen today" — to list the people registered in the org, or to work with person label groups (e.g. "Engineering", "Visitors").
 
-If the user is asking about how many people were seen (head count / occupancy), use the report-tool with GET_OCCUPANCY_ENABLED_CAMERAS and GET_OCCUPANCY_COUNT_REPORT instead. This tool (faces-tool) is best for identifying *who* was seen (unique individuals by name), and its face count data is also automatically included in report-tool people-counting responses via the faceCountEnrichment field.
+**Head counts are a different tool:** if the user asks how MANY people were seen (head count / occupancy), use report-tool with GET_OCCUPANCY_ENABLED_CAMERAS and GET_OCCUPANCY_COUNT_REPORT instead. Its people-counting responses already carry this tool's unique-face data in the faceCountEnrichment field.
 
-**Important for person-presence questions:** When asked whether specific people were seen or are present, you should ALSO check badge-in records for the same time range: the vendor badge tools (onguard-events-tool / elements-events-tool / netbox-events-tool — call all three in parallel; each returns empty when not configured) and events-tool with eventType "access-control" (native Rhombus doors) or "brivo-access-control" (Brivo). Face recognition and access control are complementary — someone may badge in without face recognition triggering, or be seen by a camera without badging in.
+**Important for person-presence questions:** when asked whether specific people were seen or are present, you should ALSO check badge-in records for the same time range — the vendor badge tools (onguard-events-tool / elements-events-tool / netbox-events-tool; call all three in parallel, each returns empty when not configured) and events-tool with eventType "access-control" (native Rhombus doors) or "brivo-access-control" (Brivo). Face recognition and access control are complementary: someone may badge in without face recognition triggering, or be seen by a camera without badging in.
 
-If the requestType is "get-face-events":
-- Use this tool to answer questions about face sightings, including questions like "who was in the office" or "who was seen today". Can be used for reporting, to generate a report on who was seen by the camera system.
-- **Automatic name resolution:** You can pass partial or first-name-only names in faceNames (e.g., "Brandon", "Omar"). The tool automatically looks up the registered faces directory and resolves them to exact names and person UUIDs before searching. Check the "resolvedNames" field in the response to see what each queried name was matched to (null means no match found).
-- You can filter face events using parameters like 'faceNames', 'hasEmbedding', 'hasName', 'labels', 'locationUuids', 'personUuids', and a time range using 'rangeStart' and 'rangeEnd' (timestamps in milliseconds).
-- If you'd like to know about all face events at a location, pass in a location UUID and no device UUIDs. This will correctly return all face events at that location.
-- When the user asks about a specific person at a location (e.g. "Jane Doe at Main Office"), call get-registered-faces first to get the list of registered names, find the best match, then call get-face-events with that precise name. The tool expects precise names as stored in the system.
-- When querying faces at a location, pass only the location UUID in searchFilter; do not pass device UUIDs in searchFilter.deviceUuids, so the API returns all faces detected at that location.
-
-If the requestType is "get-registered-faces":
-- This tool retrieves a list of all people (registered faces) currently known to the Rhombus system for your organization. This list includes information about each registered person, including their assigned labels.
-- This returns ALL people registered in the system, regardless of the provided timestampFilter.
-- Each person in the response includes a "labels" array showing which label groups they belong to (e.g., "Engineering", "Visitors"). Use these labels to answer questions about groups of people.
-
-If the requestType is "get-person-labels":
-- This retrieves a mapping of all person UUIDs to their assigned labels across the organization.
-- Use this to discover what label groups exist and which registered faces belong to each group.
-- Useful when the user asks about a group (e.g., "was anyone from Engineering seen today?") — get the labels first, find the person UUIDs for that label, then query face events filtered by those personUuids or labels.
+Per-requestType behaviour — automatic name resolution, the available filters, and how to query a whole location — is documented on the requestType parameter.
 `;
 
 const TOOL_HANDLER = async (args: ToolArgs, extra: unknown) => {

--- a/src/tools-console/lost-badge-tool.ts
+++ b/src/tools-console/lost-badge-tool.ts
@@ -3,26 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getLostBadgeResponse } from "../api/lost-badge-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/lost-badge-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildLostBadgeToolDescription } from "../types/lost-badge-tool-types.js";
 
 const TOOL_NAME = "lost-badge-tool";
 
-const TOOL_DESCRIPTION = `
-Lost / stolen-badge live response for Honeywell OnGuard (Lenel) access. Use for "a lost badge was just used —
-who is it and where did they go?", or to review lost/inactive-badge use over a window.
-
-For each lost/inactive-badge use it returns:
-- cardholderOfRecord (who the badge belongs to — may NOT be who used it) and badgeStatus
-- the door deviceUuid + time, plus clipHint / stillHint for the door footage
-- facesAtDoor: the face(s) captured at the door at that moment — a recognized name, or UNIDENTIFIED (an unknown
-  face on a valid badge is the strongest stolen/shared-badge signal), with a thumbnail
-- sightings: that same face tracked across cameras, ordered in time, ending in lastKnownSighting (last-known location)
-
-Resolve relative times (e.g. "in the last hour") to ISO 8601 first via time-tool.
-
-To present: show the door still/clip (camera-tool image / clips-tool createClip with the hints), the face at the
-door, and the cross-camera track to last-known location. Detection + door evidence are reliable; the face track
-depends on face-recognition coverage, so treat it as investigative, not proof.
-`;
+const TOOL_DESCRIPTION = buildLostBadgeToolDescription("Honeywell OnGuard (Lenel)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/netbox-access-anomaly-tool.ts
+++ b/src/tools-console/netbox-access-anomaly-tool.ts
@@ -3,28 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getNetboxAccessAnomalies } from "../api/netbox-access-anomaly-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/netbox-access-anomaly-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildAccessAnomalyToolDescription } from "../types/access-anomaly-tool-types.js";
 
 const TOOL_NAME = "netbox-access-anomaly-tool";
 
-const TOOL_DESCRIPTION = `
-Scans Lenel S2 NetBox (Honeywell NetBox) access events over a time window and flags anomalous badge activity. Use for
-"find unusual badge activity", "anything suspicious in access this week", or proactive access review.
-
-Runs deterministic rules and returns ranked findings (high severity first):
-- lost_or_inactive_badge: a non-active badge (lost/suspended) was used
-- entry_not_made: access granted but no entry made (possible tailgating)
-- off_hours: entry outside business hours (configurable)
-- impossible_travel: one cardholder at two different areas seconds apart
-- area_novelty: a cardholder's first-ever entry to an area vs their prior history (needs a baseline window)
-
-Each finding includes cardholderName, the rule, severity, datetime, area, the camera deviceUuid, a plain-language
-rationale, and clip/still hints. Resolve relative times (e.g. "this week") to ISO 8601 first via time-tool.
-
-This is a triage aid: present findings grouped by severity, and for the notable ones call the camera-tool
-(requestType "image", cameraUuid = finding.deviceUuid, timestampISO = the finding's time as ISO 8601 — convert finding.timestampMs via time-conversion-tool) and/or clips-tool
-("createClip" using finding.clipHint) — in PARALLEL — so a human can confirm. Don't assert wrongdoing; surface the
-evidence.
-`;
+const TOOL_DESCRIPTION = buildAccessAnomalyToolDescription("Lenel S2 NetBox (Honeywell NetBox)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/netbox-badge-timeline-tool.ts
+++ b/src/tools-console/netbox-badge-timeline-tool.ts
@@ -3,30 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getNetboxBadgeTimeline } from "../api/netbox-badge-timeline-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/netbox-badge-timeline-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildBadgeTimelineToolDescription } from "../types/badge-timeline-tool-types.js";
 
 const TOOL_NAME = "netbox-badge-timeline-tool";
 
-const TOOL_DESCRIPTION = `
-Reconstructs one person's movements through a building from their Lenel S2 NetBox (Honeywell NetBox) badge taps.
-Use this for incident reconstruction / "follow the badge" requests, e.g. "reconstruct Eve's movements
-yesterday" or "where did this cardholder go".
-
-Returns the cardholder's badge taps in CHRONOLOGICAL order (oldest first), each with:
-- datetime / timestampMs and the area entered
-- deviceUuid: the camera at that door
-- clipHint (camera + start/end window) and stillHint (camera + timestamp)
-- gapToNextSeconds: time until the next tap (a large gap = unobserved movement between doors)
-plus a "path" array summarizing the areas traversed in order.
-
-Resolve relative times like "yesterday" to ISO 8601 first (use time-tool), then pass
-startTime/endTime. cardholderQuery is a full-text name match; if "ambiguousCardholders" is returned the
-query matched more than one person — ask the user which one before trusting the timeline.
-
-IMPORTANT — to show the movement visually: for each stop (or the key transitions), call the camera-tool
-(requestType "image", cameraUuid = stop.deviceUuid, timestampISO = the stop's time as ISO 8601 — convert stop.timestampMs via time-conversion-tool) for a still you can see,
-and/or the clips-tool (requestType "createClip", using stop.clipHint) for video. Issue those per-stop
-media calls in PARALLEL, then present the timeline as a chronological narrative.
-`;
+const TOOL_DESCRIPTION = buildBadgeTimelineToolDescription("Lenel S2 NetBox (Honeywell NetBox)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/netbox-lost-badge-tool.ts
+++ b/src/tools-console/netbox-lost-badge-tool.ts
@@ -3,26 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getNetboxLostBadgeResponse } from "../api/netbox-lost-badge-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/netbox-lost-badge-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
+import { buildLostBadgeToolDescription } from "../types/lost-badge-tool-types.js";
 
 const TOOL_NAME = "netbox-lost-badge-tool";
 
-const TOOL_DESCRIPTION = `
-Lost / stolen-badge live response for Lenel S2 NetBox (Honeywell NetBox) access. Use for "a lost badge was just used —
-who is it and where did they go?", or to review lost/inactive-badge use over a window.
-
-For each lost/inactive-badge use it returns:
-- cardholderOfRecord (who the badge belongs to — may NOT be who used it) and badgeStatus
-- the door deviceUuid + time, plus clipHint / stillHint for the door footage
-- facesAtDoor: the face(s) captured at the door at that moment — a recognized name, or UNIDENTIFIED (an unknown
-  face on a valid badge is the strongest stolen/shared-badge signal), with a thumbnail
-- sightings: that same face tracked across cameras, ordered in time, ending in lastKnownSighting (last-known location)
-
-Resolve relative times (e.g. "in the last hour") to ISO 8601 first via time-tool.
-
-To present: show the door still/clip (camera-tool image / clips-tool createClip with the hints), the face at the
-door, and the cross-camera track to last-known location. Detection + door evidence are reliable; the face track
-depends on face-recognition coverage, so treat it as investigative, not proof.
-`;
+const TOOL_DESCRIPTION = buildLostBadgeToolDescription("Lenel S2 NetBox (Honeywell NetBox)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/netbox-tool.ts
+++ b/src/tools-console/netbox-tool.ts
@@ -7,7 +7,7 @@ import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "netbox-events-tool";
 
-const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Lenel S2 NetBox (Honeywell NetBox)");
+const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Lenel S2 NetBox (Honeywell NetBox)", "NetBox");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/netbox-tool.ts
+++ b/src/tools-console/netbox-tool.ts
@@ -2,42 +2,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { searchNetboxEvents } from "../api/netbox-tool-api.js";
 import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/netbox-tool-types.js";
+import { buildBadgeEventsToolDescription } from "../types/onguard-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "netbox-events-tool";
 
-const TOOL_DESCRIPTION = `
-Searches Lenel S2 NetBox (Honeywell NetBox) badge / access-control events for the organization. Use this to answer
-"who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday".
-
-NOTE: an organization may run any combination of Honeywell OnGuard (Lenel), Honeywell Elements (LenelS2
-Elements), and Lenel S2 NetBox badge integrations — each searched by its own sibling tool
-(onguard-events-tool / elements-events-tool / netbox-events-tool), all taking identical arguments and
-returning the same shape. For a general "who badged in / did anyone enter" question you usually do NOT
-know which integration recorded the event, so call ALL THREE sibling tools (in parallel) and combine the
-results — each returns an empty list when its integration isn't configured. Restrict to one vendor only
-when the user explicitly names it. Badge events may ALSO exist outside these three vendors: native
-Rhombus ACU doors and Brivo doors are searched via events-tool (eventType "access-control" /
-"brivo-access-control") — a deferred tool; discover it via tool search and include it for generic
-"who badged in" questions.
-
-Each returned event includes:
-- cardholderName: the person's name
-- deviceUuid: the camera that saw the event
-- timestampMs / datetime: when it happened
-- label: e.g. "NetBox: Badge Authorized" (a grant) or an anomaly label
-- badgeStatus, badgeType, areaEntering, areaExiting, entryMade, isAnomaly
-
-Filters (all optional): area, locationUuids, deviceUuids, cardholderQuery, badgeStatus, badgeType,
-anomalyOnly, entryMade, startTime, endTime, limit. Resolve relative times like "yesterday" to ISO 8601
-first (use time-tool), then pass startTime/endTime.
-
-IMPORTANT — to show pictures and video of each person so the user can visually identify them: after this
-returns, for each event (or the most relevant ones) call the camera-tool (requestType "image",
-cameraUuid = the event's deviceUuid, timestampISO = the event's time as ISO 8601 — convert its timestampMs via time-conversion-tool) to get a still you can see, and/or the
-clips-tool (requestType "createClip") with a short window around the timestamp for video. Issue those
-per-event media calls in PARALLEL.
-`;
+const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Lenel S2 NetBox (Honeywell NetBox)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/onguard-tool.ts
+++ b/src/tools-console/onguard-tool.ts
@@ -1,43 +1,17 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { searchOnGuardEvents } from "../api/onguard-tool-api.js";
-import { OUTPUT_SCHEMA, TOOL_ARGS, type ToolArgs } from "../types/onguard-tool-types.js";
+import {
+  buildBadgeEventsToolDescription,
+  OUTPUT_SCHEMA,
+  TOOL_ARGS,
+  type ToolArgs,
+} from "../types/onguard-tool-types.js";
 import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "onguard-events-tool";
 
-const TOOL_DESCRIPTION = `
-Searches Honeywell OnGuard (Lenel) badge / access-control events for the organization. Use this to answer
-"who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday".
-
-NOTE: an organization may run any combination of Honeywell OnGuard (Lenel), Honeywell Elements (LenelS2
-Elements), and Lenel S2 NetBox badge integrations — each searched by its own sibling tool
-(onguard-events-tool / elements-events-tool / netbox-events-tool), all taking identical arguments and
-returning the same shape. For a general "who badged in / did anyone enter" question you usually do NOT
-know which integration recorded the event, so call ALL THREE sibling tools (in parallel) and combine the
-results — each returns an empty list when its integration isn't configured. Restrict to one vendor only
-when the user explicitly names it. Badge events may ALSO exist outside these three vendors: native
-Rhombus ACU doors and Brivo doors are searched via events-tool (eventType "access-control" /
-"brivo-access-control") — a deferred tool; discover it via tool search and include it for generic
-"who badged in" questions.
-
-Each returned event includes:
-- cardholderName: the person's name
-- deviceUuid: the camera that saw the event
-- timestampMs / datetime: when it happened
-- label: e.g. "OnGuard: Badge Authorized" (a grant) or an anomaly label
-- badgeStatus, badgeType, areaEntering, areaExiting, entryMade, isAnomaly
-
-Filters (all optional): area, locationUuids, deviceUuids, cardholderQuery, badgeStatus, badgeType,
-anomalyOnly, entryMade, startTime, endTime, limit. Resolve relative times like "yesterday" to ISO 8601
-first (use time-tool), then pass startTime/endTime.
-
-IMPORTANT — to show pictures and video of each person so the user can visually identify them: after this
-returns, for each event (or the most relevant ones) call the camera-tool (requestType "image",
-cameraUuid = the event's deviceUuid, timestampISO = the event's time as ISO 8601 — convert its timestampMs via time-conversion-tool) to get a still you can see, and/or the
-clips-tool (requestType "createClip") with a short window around the timestamp for video. Issue those
-per-event media calls in PARALLEL.
-`;
+const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Honeywell OnGuard (Lenel)");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/onguard-tool.ts
+++ b/src/tools-console/onguard-tool.ts
@@ -11,7 +11,7 @@ import { createToolStructuredContent, extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "onguard-events-tool";
 
-const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Honeywell OnGuard (Lenel)");
+const TOOL_DESCRIPTION = buildBadgeEventsToolDescription("Honeywell OnGuard (Lenel)", "OnGuard");
 
 const TOOL_HANDLER = async (args: ToolArgs, _extra: unknown) => {
   const { requestModifiers, sessionId } = extractFromToolExtra(_extra);

--- a/src/tools-console/report-tool.ts
+++ b/src/tools-console/report-tool.ts
@@ -25,50 +25,20 @@ import { extractFromToolExtra } from "../util.js";
 
 const TOOL_NAME = "report-tool";
 
+// Tool descriptions are billed on EVERY LLM call even while the tool is
+// deferred behind hosted tool_search, so this string carries only what the
+// model needs to CHOOSE this tool. Per-requestType behaviour, call ordering,
+// and the people/occupancy strategy live on the requestType parameter
+// description (unbilled until the tool is loaded, still in front of the model
+// when it builds the call). See PERF_MASTER_PLAN P2 #4a.
 const TOOL_DESCRIPTION = `
-**Scope:** This tool returns **aggregated counts and time-series summaries** over specified intervals and scopes. Use **events-tool** when you need raw, event-level data (individual events with timestamps). Use this tool for high-level reports, analytics, and trends—especially over periods of a day or more.
+**Scope:** **aggregated counts and time-series summaries** over specified intervals and scopes (device, location, region, org). Use **events-tool** when you need raw, event-level data (individual events with timestamps). Use this tool for high-level reports, analytics, and trends—especially over periods of a day or more.
+
+Covers: people counting and occupancy reports (enriched with unique-face counts), line-crossing / threshold ingress-egress counts, custom LLM event reports and their prompt configurations (e.g. "black dog sightings", "delivery truck arrivals", "parking availability %"), the org audit log of user and admin actions, device diagnostic feeds, and the most recent people-count readings for a device.
+
+Pick one with "requestType". Each type's arguments, response enrichment, and required call ordering (some types must be called first to discover which cameras support a feature) are documented on the requestType parameter.
 
 **Interval guidance:** A shorter interval (HOURLY instead of DAILY) gives a better representation of data over time. Balance interval and range so you don't request too much data. For ranges spanning a week or so, HOURLY is appropriate.
-
----
-
-**People / occupancy counting strategy**
-
-When asked to count people on a camera or at a location, follow this strategy:
-1. **Always call GET_OCCUPANCY_ENABLED_CAMERAS first** to discover which cameras have occupancy counting enabled.
-2. If the target camera IS in the list, call **GET_OCCUPANCY_COUNT_REPORT** for that device. The response will automatically include a \`faceCountEnrichment\` field with the number of unique individuals identified by face recognition in the same time range. Present both data sources: occupancy estimate and unique face count.
-3. If the target camera is NOT in the list, **tell the user** that camera does not have occupancy counting enabled, and list the cameras that do. You can still call GET_SUMMARY_COUNT_REPORT with PEOPLE type — its response will also include \`faceCountEnrichment\` with unique face data as a fallback. If the PEOPLE count returns zero, the response will also include the list of occupancy-enabled cameras and a hint.
-4. When both occupancy data and face recognition data are available, **synthesize both** in your answer (e.g., "Occupancy estimates ~15 people. Face recognition identified 9 unique individuals during this period.").
-
-**PEOPLE type (in GET_SUMMARY_COUNT_REPORT):** Not a unique person count; it counts people-detection events. Requires people detection to be enabled on the camera. Use for high-level activity trends, not for deduplicated head counts.
-
----
-
-**Summary and occupancy**
-- **GET_SUMMARY_COUNT_REPORT:** Aggregated counts (people, faces, motion, vehicles, etc.) over time at device, location, or org scope. Interval: minutely, hourly, daily, weekly, monthly, yearly. When called with PEOPLE type at DEVICE scope, the response is automatically enriched with face recognition data.
-- **GET_OCCUPANCY_ENABLED_CAMERAS:** List of cameras with occupancy reporting enabled. **Always call this first** before any people/occupancy counting request to verify camera support.
-- **GET_OCCUPANCY_COUNT_REPORT:** Occupancy count time series for a specific device over a time range. Response is automatically enriched with face recognition data. If the device does not support occupancy, the response will include a hint and the list of cameras that do.
-
----
-
-**Line crossing**
-- **GET_LINE_CROSSING_ENABLED_CAMERAS:** Cameras at a location with line crossing enabled, plus their configs. Call first to see which cameras support threshold crossing reports.
-- **GET_THRESHOLD_CROSSING_COUNT_REPORT:** Ingress/egress counts for line crossings over time. Supports human and vehicle detection; bucket size: quarter hour, hour, day, week. Response includes computed metrics: average entries/exits per hour, hour with most entries/exits, busiest hour (with breakdown).
-
----
-
-**Custom LLM events**
-- **FIND_PROMPT_CONFIGURATIONS:** All custom event prompt configurations (e.g. "black dog sightings", "delivery truck arrivals", "parking availability %"). Each has prompt text, UUID, and promptType (COUNT, PERCENT, BOOLEAN). Call first to discover available custom events.
-- **GET_CUSTOM_LLM_REPORT:** **This is the PRIMARY way to get custom event reports.** Aggregated time-series for one custom event by prompt UUID. Automatically selects the correct API based on promptType: COUNT (numeric counts), PERCENT (percentages), BOOLEAN (true/false). Intervals: minutely, quarter-hourly, hourly, daily, weekly, monthly. **Always use this for custom event reports, trends, and analytics.** Use FIND_PROMPT_CONFIGURATIONS first to get the promptUuid and promptType.
-- **GET_CUSTOM_EVENTS_REPORT:** Raw individual event values only (not aggregated). Use only when you need per-event granularity, not for reports or trends.
-
----
-
-**Audit and diagnostics**
-- **GET_AUDIT_FEED:** Audit log of all user/admin actions in the org over a time range. Returns who did what and when (principalName, targetName, action, displayText).
-- **GET_DIAGNOSTIC_FEED:** Device diagnostic events over a time range.
-- **GET_THRESHOLD_CROSSING_EVENTS:** Individual line-crossing events (not aggregated counts).
-- **GET_PEOPLE_COUNT_EVENTS:** Most recent people count readings for specified devices.
 `;
 
 const TOOL_HANDLER = async (args: ToolArgs, extra: unknown) => {

--- a/src/types/access-anomaly-tool-types.ts
+++ b/src/types/access-anomaly-tool-types.ts
@@ -11,6 +11,21 @@ export const ANOMALY_RULES = [
   "area_novelty",
 ] as const;
 
+/**
+ * Description shared by the three access-anomaly tools (OnGuard / Elements /
+ * NetBox), which differ only in vendor. Kept short because tool descriptions
+ * are billed on every LLM call even while deferred, and this text is
+ * duplicated across all three siblings; rule detail and triage guidance live
+ * on the arguments below. See PERF_MASTER_PLAN P2 #4a.
+ */
+export function buildAccessAnomalyToolDescription(vendor: string): string {
+  return `
+Scans ${vendor} access events over a time window and flags anomalous badge activity. Use for "find unusual badge activity", "anything suspicious in access this week", or proactive access review.
+
+Runs deterministic rules — a lost/suspended badge was used, access granted but no entry made (possible tailgating), off-hours entry, impossible travel between areas, and first-ever entry to an area — and returns ranked findings (high severity first) with cardholderName, the rule, severity, datetime, area, the camera deviceUuid, a plain-language rationale, and clip/still hints.
+`;
+}
+
 export const TOOL_ARGS = {
   area: z.string().nullable().describe("Optional: restrict analysis to events entering this area (full-text)."),
   locationUuids: z
@@ -22,7 +37,10 @@ export const TOOL_ARGS = {
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
     .nullable()
-    .describe("Start of the window to analyze (inclusive). " + ISOTimestampFormatDescription),
+    .describe(
+      'Start of the window to analyze (inclusive). Resolve relative phrasing like "this week" with time-tool first, then pass ISO 8601 here. ' +
+        ISOTimestampFormatDescription
+    ),
   endTime: z
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
@@ -32,7 +50,12 @@ export const TOOL_ARGS = {
     .array(z.enum(ANOMALY_RULES))
     .nullable()
     .describe(
-      "Which rules to run; default all. Options: lost_or_inactive_badge, entry_not_made, off_hours, impossible_travel, area_novelty."
+      "Which rules to run; default all. Options: lost_or_inactive_badge (a non-active badge — lost or suspended — was used), " +
+        "entry_not_made (access granted but no entry made, possible tailgating), off_hours (entry outside business hours, configurable), " +
+        "impossible_travel (one cardholder at two different areas seconds apart), area_novelty (a cardholder's first-ever entry to an area vs their prior history; needs a baseline window). " +
+        "This tool is a triage aid: present findings grouped by severity, and for the notable ones call camera-tool " +
+        '(requestType "image", cameraUuid = finding.deviceUuid, timestampISO = the finding\'s time — convert finding.timestampMs with time-conversion-tool) ' +
+        'and/or clips-tool ("createClip" using finding.clipHint) IN PARALLEL so a human can confirm. Do not assert wrongdoing; surface the evidence.'
     ),
   baselineDays: z
     .number()

--- a/src/types/badge-timeline-tool-types.ts
+++ b/src/types/badge-timeline-tool-types.ts
@@ -3,10 +3,27 @@ import { z } from "zod";
 import { createUuidSchema } from "../types.js";
 import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
 
+/**
+ * Description shared by the three badge-timeline tools (OnGuard / Elements /
+ * NetBox), which differ only in vendor. Kept short because tool descriptions
+ * are billed on every LLM call even while deferred, and this text is
+ * duplicated across all three siblings; the how-to-present guidance lives on
+ * the arguments below. See PERF_MASTER_PLAN P2 #4a.
+ */
+export function buildBadgeTimelineToolDescription(vendor: string): string {
+  return `
+Reconstructs one person's movements through a building from their ${vendor} badge taps. Use this for incident reconstruction / "follow the badge" requests, e.g. "reconstruct Eve's movements yesterday" or "where did this cardholder go".
+
+Returns the cardholder's badge taps in CHRONOLOGICAL order (oldest first) — datetime, the area entered, deviceUuid of the camera at that door, clip/still hints, and gapToNextSeconds (a large gap means unobserved movement between doors) — plus a "path" array summarizing the areas traversed in order.
+`;
+}
+
 export const TOOL_ARGS = {
   cardholderQuery: z
     .string()
-    .describe('The cardholder (person) to reconstruct, full-text name match, e.g. "Eve" or "Eve Adams".'),
+    .describe(
+      'The cardholder (person) to reconstruct, full-text name match, e.g. "Eve" or "Eve Adams". If the response contains "ambiguousCardholders" the query matched more than one person — ask the user which one before trusting the timeline.'
+    ),
   locationUuids: z
     .array(createUuidSchema())
     .nullable()
@@ -15,7 +32,10 @@ export const TOOL_ARGS = {
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
     .nullable()
-    .describe("Start of the window (inclusive). " + ISOTimestampFormatDescription),
+    .describe(
+      'Start of the window (inclusive). Resolve relative phrasing like "yesterday" with time-tool first, then pass ISO 8601 here. ' +
+        ISOTimestampFormatDescription
+    ),
   endTime: z
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
@@ -24,7 +44,9 @@ export const TOOL_ARGS = {
   clipPaddingSeconds: z
     .number()
     .nullable()
-    .describe("Seconds of video before/after each badge tap to include in the clip hint (default 15)."),
+    .describe(
+      "Seconds of video before/after each badge tap to include in the clip hint (default 15). To show the movement visually after this returns: for each stop (or the key transitions) call camera-tool (requestType \"image\", cameraUuid = stop.deviceUuid, timestampISO = the stop's time — convert stop.timestampMs with time-conversion-tool) for a still, and/or clips-tool (requestType \"createClip\", using stop.clipHint) for video. Issue those per-stop media calls IN PARALLEL, then present the timeline as a chronological narrative."
+    ),
   limit: z.number().nullable().describe("Maximum badge taps to include (default 200)."),
   timeZone: z
     .string()

--- a/src/types/camera-tool-types.ts
+++ b/src/types/camera-tool-types.ts
@@ -252,7 +252,24 @@ export const BASE_TOOL_ARGS = {
       the timestamp for the image. This will default to 5 minutes before the current time. You can also call time-tool to parse the user's time description.
       ` + ISOTimestampFormatDescription
     ),
-  requestType: z.enum(["image", "get-settings", "get-media-uris", "get-ai-thresholds"]),
+  requestType: z
+    .enum(["image", "get-settings", "get-media-uris", "get-ai-thresholds"])
+    .describe(
+      `Which camera action to run: "image" (fetch a frame), "get-settings" (current device configuration), "get-media-uris" (live-stream and VOD URLs), "get-ai-thresholds" (AI detection thresholds).
+
+**AUTOMATIC SNAPSHOT FOR IMAGE QUALITY ISSUES** — when a user mentions camera image quality (darkness, brightness, blur, washed out, "doesn't look great", "fix the image", etc.), you MUST IMMEDIATELY:
+1. Call camera-tool with requestType "image" to capture a snapshot WITHOUT asking first.
+2. Analyze the image to identify quality issues.
+3. Call camera-tool with requestType "get-settings" to check current camera settings.
+4. Propose specific setting changes based on your analysis (store the exact values you plan to change, e.g. img_brightness, wdr_strength).
+5. When the user confirms ("yes", "confirm", "fix it", "apply", "go ahead", "ok", etc.), call update-tool with those stored settings — see update-tool's description for the confirmation flow. NEVER skip the update-tool call.
+
+**VISUAL-FEATURE CAMERA FILTERING** — when the user asks for cameras filtered by what they can see (indoors/outdoors, "facing the street", "with a view of X", parking lot, entrance), you MUST:
+1. First get the camera list via get-entity-tool or location-tool.
+2. Then call camera-tool with requestType "image" for EACH candidate camera (in PARALLEL).
+3. Analyze each image to determine if it meets the user's criteria.
+4. Return only the cameras that match.`,
+    ),
   detail: z
     .enum(["core", "full"])
     .nullish()

--- a/src/types/events-tools-types.ts
+++ b/src/types/events-tools-types.ts
@@ -21,17 +21,17 @@ export const TOOL_ARGS = {
   eventType: z
     .nativeEnum(EventsToolRequestType)
     .describe(
-      "The type of events to retrieve. " +
-        "access-control: Access control events like unlocks, badge ins, credentials, arrivals. " +
-        "brivo-access-control: Badge/credential events from Brivo-integrated doors. Does not require door UUIDs — automatically looks up which doors are configured via the Brivo integration. " +
-        "environmental-gateway: Environmental gateway events with sensor readings and derived values. " +
-        "climate-sensor: Climate sensor events with temperature, humidity, air quality readings. " +
-        "component-events: All types of component events for a location (most flexible option). " +
-        "camera: Footage seekpoints for one camera—all timeline activity types that camera recorded (human motion, vehicle motion, etc., depending on device/analytics). For org LPR saved vehicles, labels, and plate search APIs, use lpr-tool. " +
-        "button-press: Button press events from button sensors. " +
-        "occupancy: Occupancy sensor events with people count. " +
-        "proximity: Proximity tag events with RSSI readings. " +
-        "doorbell: Doorbell camera events."
+      "The type of events to retrieve. Every mode takes startTime and endTime (ISO 8601); the per-mode UUID argument is named below and in that argument's own description.\n\n" +
+        "access-control: Access control events (arrivals, badge ins, credentials, unlocks) for the doors in accessControlledDoorUuids. Can return a lot of data — use a narrow time range. The returned `credSource` field says how the event was triggered: REMOTE = Rhombus Key app remote unlock; 'REMOTE (Admin)' = unlock via the Rhombus console or browser/mobile app; BLE_WAVE = user waved a hand over the reader; NFC = user tapped a badge or phone on the reader.\n" +
+        "brivo-access-control: Badge/credential events from Brivo-integrated doors. Does not require door UUIDs — automatically fetches the Brivo integration configuration to determine which locations have Brivo doors mapped. Returns integrationEnabled, brivoDoorsConfigured, the brivoDoors list (Brivo IDs, names, Rhombus location UUIDs), and credential-received events newest first. Events are fetched at the LOCATION level, so results may include events from all access-controlled doors at locations where Brivo is configured.\n" +
+        "environmental-gateway: Environmental gateway events (sensor readings and derived values) for deviceUuid.\n" +
+        "climate-sensor: Climate sensor events (temperature, humidity, air quality, vape/THC detection, battery) for sensorUuid. Cap the row count with limit (default 1000).\n" +
+        "component-events: All component event types for locationUuid — the most flexible option. Narrow it with componentEventTypes (see that argument for the full list; omit it for every type).\n" +
+        "camera: Footage seekpoints for cameraUuid over a window of `duration` seconds starting at startTime — all timeline activity types that camera recorded (human motion, vehicle motion, etc., depending on device/analytics), each with an activity string and timestamp; plate/vehicle/face fields appear when the API provides them. For org LPR saved vehicles, labels, and plate search APIs, use lpr-tool.\n" +
+        "button-press: Button press events from the sensor in buttonSensorUuid.\n" +
+        "occupancy: Occupancy sensor events with people count, for occupancySensorUuid.\n" +
+        "proximity: Proximity tag events with RSSI readings, for proximityTagUuids.\n" +
+        "doorbell: Doorbell camera events for doorbellCameraUuid."
     ),
   startTime: z
     .string()
@@ -94,7 +94,7 @@ export const TOOL_ARGS = {
   timeZone: z
     .string()
     .describe(
-      "The timezone of the requested locations or devices. This is necessary for the tool to produce accurate formatted timestamps."
+      "The timezone of the requested locations or devices. This is necessary for the tool to produce accurate formatted timestamps. Formatted event timestamps come back in the device / sensor / location timezone, not necessarily UTC."
     ),
   cameraUuid: z
     .string()

--- a/src/types/faces-tools-types.ts
+++ b/src/types/faces-tools-types.ts
@@ -115,7 +115,19 @@ export const GetFaceEventsArgs = z.object({
 export type GetFaceEventsArgs = z.infer<typeof GetFaceEventsArgs>;
 
 export const TOOL_ARGS = {
-  requestType: z.nativeEnum(RequestType),
+  requestType: z.nativeEnum(RequestType).describe(
+    `Which face-recognition request to run.
+
+"get-face-events" — face sightings; use it for reporting on who was seen by the camera system.
+- **Automatic name resolution:** faceNames accepts partial or first-name-only names (e.g. "Brandon", "Omar"); the tool looks up the registered-faces directory and resolves them to exact names and person UUIDs before searching. The response's "resolvedNames" field shows what each queried name matched (null = no match).
+- Filter with faceNames, hasEmbedding, hasName, labels, locationUuids, personUuids, and a time range via rangeStart / rangeEnd (milliseconds).
+- For all face events at a location, pass only the location UUID in searchFilter and NO device UUIDs (searchFilter.deviceUuids), so the API returns every face detected there.
+- When the user asks about a specific person at a location (e.g. "Jane Doe at Main Office"), call get-registered-faces first, find the best match, then call get-face-events with that precise name — this request expects names exactly as stored.
+
+"get-registered-faces" — every person (registered face) known to the org, each with a "labels" array showing the label groups they belong to. Returns ALL people regardless of any timestamp filter.
+
+"get-person-labels" — a mapping of person UUIDs to their assigned labels across the org. Use it to discover what label groups exist; for a group question ("was anyone from Engineering seen today?") get the labels first, then query face events filtered by those personUuids or labels.`,
+  ),
   faceEventFilter: GetFaceEventsArgs,
   timeZone: z
     .string()

--- a/src/types/lost-badge-tool-types.ts
+++ b/src/types/lost-badge-tool-types.ts
@@ -3,6 +3,21 @@ import { z } from "zod";
 import { createUuidSchema } from "../types.js";
 import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
 
+/**
+ * Description shared by the three lost-badge tools (OnGuard / Elements /
+ * NetBox), which differ only in vendor. Kept short because tool descriptions
+ * are billed on every LLM call even while deferred, and this text is
+ * duplicated across all three siblings; presentation guidance and the
+ * reliability caveat live on the arguments below. See PERF_MASTER_PLAN P2 #4a.
+ */
+export function buildLostBadgeToolDescription(vendor: string): string {
+  return `
+Lost / stolen-badge live response for ${vendor} access. Use for "a lost badge was just used — who is it and where did they go?", or to review lost/inactive-badge use over a window.
+
+For each lost/inactive-badge use it returns cardholderOfRecord (who the badge belongs to — may NOT be who used it) and badgeStatus, the door deviceUuid + time with clip/still hints, facesAtDoor (the face captured at the door — a recognized name, or UNIDENTIFIED, which on a valid badge is the strongest stolen/shared-badge signal), and sightings of that same face tracked across cameras in time order, ending in lastKnownSighting.
+`;
+}
+
 export const TOOL_ARGS = {
   area: z.string().nullable().describe("Optional: restrict to events entering this area (full-text)."),
   locationUuids: z.array(createUuidSchema()).nullable().describe("Optional: restrict to these location UUIDs."),
@@ -11,7 +26,10 @@ export const TOOL_ARGS = {
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
     .nullable()
-    .describe("Start of the window to scan for lost/inactive-badge use (inclusive). " + ISOTimestampFormatDescription),
+    .describe(
+      'Start of the window to scan for lost/inactive-badge use (inclusive). Resolve relative phrasing like "in the last hour" with time-tool first, then pass ISO 8601 here. ' +
+        ISOTimestampFormatDescription
+    ),
   endTime: z
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
@@ -20,7 +38,9 @@ export const TOOL_ARGS = {
   faceWindowSeconds: z
     .number()
     .nullable()
-    .describe("± seconds around each badge event to look for the face at the door (default 30)."),
+    .describe(
+      "± seconds around each badge event to look for the face at the door (default 30). To present the result: show the door still/clip (camera-tool requestType \"image\" / clips-tool \"createClip\" with the returned hints), the face at the door, and the cross-camera track to the last-known location. Detection and door evidence are reliable; the face track depends on face-recognition coverage, so treat it as investigative, not proof."
+    ),
   limit: z.number().nullable().describe("Max badge events to scan in the window (default 50)."),
   timeZone: z
     .string()

--- a/src/types/onguard-tool-types.ts
+++ b/src/types/onguard-tool-types.ts
@@ -3,6 +3,26 @@ import { z } from "zod";
 import { createUuidSchema } from "../types.js";
 import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
 
+/**
+ * Description shared by the three badge-integration event tools
+ * (onguard-events-tool / elements-events-tool / netbox-events-tool), which
+ * differ only in vendor.
+ *
+ * Kept deliberately short: tool descriptions are billed on EVERY LLM call even
+ * while the tool is deferred behind hosted tool_search, and this text is
+ * duplicated across all three siblings. Filter semantics live on the arguments
+ * below (unbilled until the tool loads). See PERF_MASTER_PLAN P2 #4a.
+ */
+export function buildBadgeEventsToolDescription(vendor: string): string {
+  return `
+Searches ${vendor} badge / access-control events for the organization. Use this to answer "who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday". Each event carries cardholderName (the person), deviceUuid (the camera that saw it), timestampMs/datetime, label (e.g. "${vendor.split(" ")[0]}: Badge Authorized" for a grant, or an anomaly label), badgeStatus, badgeType, areaEntering, areaExiting, entryMade, isAnomaly.
+
+**Siblings — for a generic "who badged in / did anyone enter" question, call ALL THREE in parallel:** onguard-events-tool, elements-events-tool and netbox-events-tool take identical arguments and return the same shape; an org may run any combination of those integrations, and each returns an empty list when its integration isn't configured. Narrow to one vendor only when the user names it. Native Rhombus ACU doors and Brivo doors are NOT covered here — those badge events come from events-tool (eventType "access-control" / "brivo-access-control"), so include it for generic badge questions too.
+
+After results, to show who it was: per event call camera-tool (requestType "image", cameraUuid = the event's deviceUuid, timestampISO = its time) and/or clips-tool (requestType "createClip") for a short window around the timestamp — issue those media calls IN PARALLEL.
+`;
+}
+
 export const TOOL_ARGS = {
   area: z
     .string()
@@ -36,7 +56,10 @@ export const TOOL_ARGS = {
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })
     .nullable()
-    .describe("Only events at or after this time (inclusive). " + ISOTimestampFormatDescription),
+    .describe(
+      "Only events at or after this time (inclusive). Resolve relative phrasing like \"yesterday\" with time-tool first, then pass ISO 8601 here. " +
+        ISOTimestampFormatDescription
+    ),
   endTime: z
     .string()
     .datetime({ message: "Invalid datetime string. Expected ISO 8601 format.", offset: true })

--- a/src/types/onguard-tool-types.ts
+++ b/src/types/onguard-tool-types.ts
@@ -13,9 +13,9 @@ import { ISOTimestampFormatDescription } from "../utils/timestampInput.js";
  * duplicated across all three siblings. Filter semantics live on the arguments
  * below (unbilled until the tool loads). See PERF_MASTER_PLAN P2 #4a.
  */
-export function buildBadgeEventsToolDescription(vendor: string): string {
+export function buildBadgeEventsToolDescription(vendor: string, labelPrefix: string): string {
   return `
-Searches ${vendor} badge / access-control events for the organization. Use this to answer "who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday". Each event carries cardholderName (the person), deviceUuid (the camera that saw it), timestampMs/datetime, label (e.g. "${vendor.split(" ")[0]}: Badge Authorized" for a grant, or an anomaly label), badgeStatus, badgeType, areaEntering, areaExiting, entryMade, isAnomaly.
+Searches ${vendor} badge / access-control events for the organization. Use this to answer "who entered WHERE and WHEN" questions, e.g. "who entered the back office yesterday". Each event carries cardholderName (the person), deviceUuid (the camera that saw it), timestampMs/datetime, label (e.g. "${labelPrefix}: Badge Authorized" for a grant, or an anomaly label), badgeStatus, badgeType, areaEntering, areaExiting, entryMade, isAnomaly.
 
 **Siblings — for a generic "who badged in / did anyone enter" question, call ALL THREE in parallel:** onguard-events-tool, elements-events-tool and netbox-events-tool take identical arguments and return the same shape; an org may run any combination of those integrations, and each returns an empty list when its integration isn't configured. Narrow to one vendor only when the user names it. Native Rhombus ACU doors and Brivo doors are NOT covered here — those badge events come from events-tool (eventType "access-control" / "brivo-access-control"), so include it for generic badge questions too.
 

--- a/src/types/report-tool-types.ts
+++ b/src/types/report-tool-types.ts
@@ -30,7 +30,37 @@ export const TOOL_ARGS = z.object({
 		RequestType.GET_THRESHOLD_CROSSING_EVENTS,
 		RequestType.GET_CUSTOM_EVENTS_REPORT,
 		RequestType.GET_PEOPLE_COUNT_EVENTS,
-	]),
+	]).describe(
+		`Which report to run.
+
+**People / occupancy counting strategy.** When asked to count people on a camera or at a location:
+1. **Always call GET_OCCUPANCY_ENABLED_CAMERAS first** to discover which cameras have occupancy counting enabled.
+2. If the target camera IS in the list, call **GET_OCCUPANCY_COUNT_REPORT** for that device. The response automatically includes a \`faceCountEnrichment\` field with the number of unique individuals identified by face recognition in the same time range. Present both data sources: occupancy estimate and unique face count.
+3. If the target camera is NOT in the list, **tell the user** that camera does not have occupancy counting enabled, and list the cameras that do. You can still call GET_SUMMARY_COUNT_REPORT with PEOPLE type — its response also includes \`faceCountEnrichment\` with unique face data as a fallback. If the PEOPLE count returns zero, the response also includes the list of occupancy-enabled cameras and a hint.
+4. When both occupancy data and face recognition data are available, **synthesize both** in your answer (e.g. "Occupancy estimates ~15 people. Face recognition identified 9 unique individuals during this period.").
+
+**PEOPLE type (in GET_SUMMARY_COUNT_REPORT):** not a unique person count; it counts people-detection events, and requires people detection to be enabled on the camera. Use for high-level activity trends, not for deduplicated head counts.
+
+**Summary and occupancy**
+- GET_SUMMARY_COUNT_REPORT: aggregated counts (people, faces, motion, vehicles, etc.) over time at device, location, or org scope. Interval: minutely, hourly, daily, weekly, monthly, yearly. With PEOPLE type at DEVICE scope the response is automatically enriched with face recognition data.
+- GET_OCCUPANCY_ENABLED_CAMERAS: cameras with occupancy reporting enabled. **Always call this first** before any people/occupancy counting request to verify camera support.
+- GET_OCCUPANCY_COUNT_REPORT: occupancy count time series for one device over a time range, enriched with face recognition data. If the device does not support occupancy, the response includes a hint and the list of cameras that do.
+
+**Line crossing**
+- GET_LINE_CROSSING_ENABLED_CAMERAS: cameras at a location with line crossing enabled, plus their configs. Call first to see which cameras support threshold crossing reports.
+- GET_THRESHOLD_CROSSING_COUNT_REPORT: ingress/egress counts for line crossings over time. Supports human and vehicle detection; bucket size quarter hour, hour, day, or week. Response includes computed metrics: average entries/exits per hour, hour with most entries/exits, busiest hour (with breakdown).
+- GET_THRESHOLD_CROSSING_EVENTS: individual line-crossing events (not aggregated counts).
+
+**Custom LLM events**
+- FIND_PROMPT_CONFIGURATIONS: all custom event prompt configurations. Each has prompt text, UUID, and promptType (COUNT, PERCENT, BOOLEAN). Call first to discover available custom events.
+- GET_CUSTOM_LLM_REPORT: **the PRIMARY way to get custom event reports.** Aggregated time series for one custom event by prompt UUID; automatically selects the correct API from promptType — COUNT (numeric counts), PERCENT (percentages), BOOLEAN (true/false). Intervals: minutely, quarter-hourly, hourly, daily, weekly, monthly. **Always use this for custom event reports, trends, and analytics.** Use FIND_PROMPT_CONFIGURATIONS first to get the promptUuid and promptType.
+- GET_CUSTOM_EVENTS_REPORT: raw individual event values only (not aggregated). Use only when you need per-event granularity, not for reports or trends.
+
+**Audit and diagnostics**
+- GET_AUDIT_FEED: audit log of all user/admin actions in the org over a time range — who did what and when (principalName, targetName, action, displayText).
+- GET_DIAGNOSTIC_FEED: device diagnostic events over a time range.
+- GET_PEOPLE_COUNT_EVENTS: most recent people count readings for specified devices.`,
+	),
 	occupancyCountRequest: z
 		.object({
 			deviceUuid: z

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,10 @@ import path from "path";
 import { DateTime } from "luxon";
 import { filterIncludedFields, applyFilterBy, type FilterCondition } from "./filtering-utils.js";
 
-export { INCLUDE_FIELDS_ARG, FILTER_BY_ARG, FilterCondition, filterIncludedFields, applyFilterBy, zodToDotNotationPaths, createFilteringProxy } from "./filtering-utils.js";
+export { INCLUDE_FIELDS_ARG, FILTER_BY_ARG, filterIncludedFields, applyFilterBy, zodToDotNotationPaths, createFilteringProxy } from "./filtering-utils.js";
+// Re-exported separately as a type so per-file transpilers (tsx/esbuild) don't
+// emit a runtime import for it.
+export type { FilterCondition } from "./filtering-utils.js";
 
 export function generateRandomString(length: number): string {
   const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
To reduce the load that our tools have on the context, this PR moves much of the prompting, especially workflow prompting, into the input arguments schema. This is especially important for callers that have deferred tool loading