### PR TITLE
tests: finish brivoDoornId -> brivoDoorId rename in fixtures/assertions

### DIFF
--- a/test/filtering-utils.test.ts
+++ b/test/filtering-utils.test.ts
@@ -114,7 +114,7 @@ describe("applyFilterBy — unaffected by the protection", () => {
 // the registered outputSchema AFTER the proxy has projected it, so a required
 // field the caller did not ask for used to fail the whole call with
 // "MCP error -32602: Output validation error". Reproduced here with the shape
-// that hit prod: events-tool/brivo-access-control, where brivoDoornId is the
+// that hit prod: events-tool/brivo-access-control, where brivoDoorId is the
 // only required field under brivoDoors.
 // ---------------------------------------------------------------------------
 
@@ -126,7 +126,7 @@ const brivoOutputShape = {
       brivoDoorsConfigured: z.number(),
       brivoDoors: z.array(
         z.object({
-          brivoDoornId: z.string().describe("Brivo's door ID"),
+          brivoDoorId: z.string().describe("Brivo's door ID"),
           doorName: z.string().optional(),
           locationUuid: z.string().optional(),
         }),
@@ -141,8 +141,8 @@ const brivoResult = {
     integrationEnabled: true,
     brivoDoorsConfigured: 2,
     brivoDoors: [
-      { brivoDoornId: "11001", doorName: "Front", locationUuid: "loc-1" },
-      { brivoDoornId: "11002", doorName: "Back", locationUuid: "loc-1" },
+      { brivoDoorId: "11001", doorName: "Front", locationUuid: "loc-1" },
+      { brivoDoorId: "11002", doorName: "Back", locationUuid: "loc-1" },
     ],
   },
 };
@@ -176,7 +176,7 @@ describe("createFilteringProxy — outputSchema survives projection", () => {
       }),
     );
 
-    // The exact includeFields the model sent in prod — no brivoDoornId.
+    // The exact includeFields the model sent in prod — no brivoDoorId.
     const result = await handler(
       {
         includeFields: [
@@ -219,7 +219,7 @@ describe("createFilteringProxy — outputSchema survives projection", () => {
       async () => ({ content: [] }),
     );
     expect(config.inputSchema.includeFields.description).toContain(
-      "brivoAccessControlEvents.brivoDoors.brivoDoornId",
+      "brivoAccessControlEvents.brivoDoors.brivoDoorId",
     );
   });
 });

--- a/test/tools/events-tool.output-validation.test.ts
+++ b/test/tools/events-tool.output-validation.test.ts
@@ -44,7 +44,7 @@ function withNulledArgs(overrides: Record<string, unknown>) {
 
 // Driven end-to-end through the real SDK, because the bug lived in the SDK's
 // post-handler validation of structuredContent, not in our own code paths: the
-// proxy projected `brivoDoornId` away and the SDK then rejected the result
+// proxy projected `brivoDoorId` away and the SDK then rejected the result
 // against the unrelaxed outputSchema with "MCP error -32602". A handler-level
 // test cannot see this.
 async function callEventsTool(args: Record<string, unknown>) {
@@ -67,8 +67,8 @@ const BRIVO_RESULT = {
   integrationEnabled: true,
   brivoDoorsConfigured: 2,
   brivoDoors: [
-    { brivoDoornId: "11001", doorName: "Front Lobby", locationUuid: "loc-1" },
-    { brivoDoornId: "11002", doorName: "Rear Dock", locationUuid: "loc-2" },
+    { brivoDoorId: "11001", doorName: "Front Lobby", locationUuid: "loc-1" },
+    { brivoDoorId: "11002", doorName: "Rear Dock", locationUuid: "loc-2" },
   ],
   events: [],
 };
@@ -79,7 +79,7 @@ describe("events-tool — brivo-access-control output validation", () => {
     vi.mocked(eventsApi.getBrivoAccessControlEvents).mockResolvedValue(BRIVO_RESULT as never);
   });
 
-  it("succeeds when includeFields omits the required brivoDoornId", async () => {
+  it("succeeds when includeFields omits the required brivoDoorId", async () => {
     const result = await callEventsTool(
       withNulledArgs({
         eventType: "brivo-access-control",
@@ -109,6 +109,6 @@ describe("events-tool — brivo-access-control output validation", () => {
 
     expect(result.isError).toBeFalsy();
     const payload = JSON.parse((result.content as { text: string }[])[0].text);
-    expect(payload.brivoAccessControlEvents.brivoDoors[0].brivoDoornId).toBe("11001");
+    expect(payload.brivoAccessControlEvents.brivoDoors[0].brivoDoorId).toBe("11001");
   });
 });


### PR DESCRIPTION
Source side of the typo fix rode into ee60ecc (merged via PR #49); these test fixtures and assertions still used the old field name.