### PR TITLE
properly surface errors from `update-tool`

### DIFF
--- a/src/filtering-utils.ts
+++ b/src/filtering-utils.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { logger } from "./logger.js";
 
 // ---------------------------------------------------------------------------
 // Shared tool arg schemas
@@ -726,10 +727,53 @@ function applyFilteringToResult(
 }
 
 /**
+ * Backstop for the single most damaging tool-result mistake in this codebase: a
+ * tool that registers an `outputSchema` but returns `{content: [...]}` with no
+ * `structuredContent`. The SDK's validateToolOutput then throws
+ *   "MCP error -32602: Tool <x> has an output schema but no structured content"
+ * which REPLACES the tool's own text. Because these are almost always error
+ * paths, the message the model needed ("img_sharpness must be at most 11",
+ * "doorControllerUuid is required") is exactly what gets destroyed — the model
+ * is left with an opaque protocol failure, retries identical args, and gives up.
+ * That shipped to prod at least twice.
+ *
+ * Setting `isError` makes the SDK skip output validation entirely, so the text
+ * survives. This is a safety net, NOT a license to skip `structuredContent` in
+ * new tools: it can only flag the result as an error, so a legitimate non-error
+ * text result must still carry its own `structuredContent` (see
+ * `unsupportedResult` in update-tool.ts). Hence the warn — it means "fix the tool".
+ */
+function backstopMissingStructuredContent(
+	// biome-ignore lint/suspicious/noExplicitAny: SDK CallToolResult shape
+	result: any,
+	toolName: string,
+	hasOutputSchema: boolean,
+	// biome-ignore lint/suspicious/noExplicitAny: SDK CallToolResult shape
+): any {
+	if (
+		!hasOutputSchema ||
+		!result ||
+		typeof result !== "object" ||
+		!("content" in result) ||
+		result.structuredContent ||
+		result.isError
+	) {
+		return result;
+	}
+	logger.warn(
+		`[filtering-proxy] ${toolName} returned no structuredContent despite registering an outputSchema; ` +
+			`flagging isError so the SDK does not replace the message with -32602. Fix the tool: ` +
+			`return structuredContent (or set isError) explicitly.`,
+	);
+	return { ...result, isError: true };
+}
+
+/**
  * Returns a Proxy over an McpServer that intercepts every `registerTool` call to:
  * 1. Inject `includeFields` and `filterBy` into the tool's inputSchema
  * 2. Append a description suffix explaining the filtering params
  * 3. Wrap the handler to apply filtering to the tool result
+ * 4. Backstop results that would otherwise fail SDK output validation
  *
  * Tools whose names appear in `blacklist` are registered without modification.
  *
@@ -814,12 +858,16 @@ export function createFilteringProxy(
 				const wrappedHandler = async (args: any, extra: unknown) => {
 					const { includeFields, filterBy, groupBy, ...restArgs } = args;
 					const result = await handler(restArgs, extra);
-					return applyFilteringToResult(
-						result,
-						includeFields,
-						filterBy,
-						groupBy,
-						protectedFields,
+					return backstopMissingStructuredContent(
+						applyFilteringToResult(
+							result,
+							includeFields,
+							filterBy,
+							groupBy,
+							protectedFields,
+						),
+						name,
+						Boolean(config.outputSchema),
 					);
 				};
 

--- a/src/tools-console/update-tool.ts
+++ b/src/tools-console/update-tool.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import {
   updateCameraConfig,
   getCameraDetails,
@@ -28,6 +29,91 @@ MANDATORY confirmation flow: when you have proposed camera-settings fixes and th
 
 Exact field names, LED rules, example payloads and faceted-UUID handling are documented on the parameters. The tool shows current settings before applying updates.
 `;
+
+// EVERY result from this tool must carry structuredContent: the tool registers
+// an outputSchema, and the MCP SDK rejects any non-isError result without
+// structuredContent as "MCP error -32602: ... no structured content was
+// provided" — which REPLACES the real failure text. That is how an out-of-range
+// img_sharpness once reached the user as "a system error" with nothing for the
+// model to correct, so it retried the identical bad value and gave up.
+function errorResult(text: string) {
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text }],
+    structuredContent: { needUserInput: false, success: false, message: text },
+  };
+}
+
+// "Not implemented yet" is a real answer, not a transport failure — leaving
+// isError off keeps the model relaying the message instead of reporting that
+// the tool broke.
+function unsupportedResult(text: string) {
+  return {
+    content: [{ type: "text" as const, text }],
+    structuredContent: { needUserInput: false, success: false, message: text },
+  };
+}
+
+function valueAtPath(root: unknown, path: readonly PropertyKey[]): unknown {
+  return path.reduce<unknown>(
+    (node, key) =>
+      node && typeof node === "object" ? (node as Record<PropertyKey, unknown>)[key] : undefined,
+    root
+  );
+}
+
+// The settings blocks are free-form JSON strings, so an out-of-range value is
+// the normal failure here, not an exotic one. The message MUST name the field,
+// the bound, and what was received — otherwise the model has nothing to act on.
+function describeSettingsIssues(label: string, error: z.ZodError, input: unknown): string {
+  const details = error.issues.map(issue => {
+    const field = issue.path.length ? issue.path.join(".") : label;
+    const received = valueAtPath(input, issue.path);
+    const suffix = received === undefined ? "" : ` (received ${JSON.stringify(received)})`;
+    if (issue.code === "too_big") {
+      return `${field} must be at most ${(issue as z.core.$ZodIssueTooBig).maximum}${suffix}`;
+    }
+    if (issue.code === "too_small") {
+      return `${field} must be at least ${(issue as z.core.$ZodIssueTooSmall).minimum}${suffix}`;
+    }
+    return `${field}: ${issue.message}${suffix}`;
+  });
+  return `Invalid ${label}: ${details.join("; ")}. Check the allowed ranges documented on this tool's parameters, then call again with in-range values. No settings were changed.`;
+}
+
+function parseSettingsBlock<T extends z.ZodType>(
+  label: string,
+  raw: string,
+  schema: T,
+  normalize?: (value: Record<string, unknown>) => void
+): { ok: true; value: z.infer<T> } | { ok: false; message: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Invalid ${label}: not valid JSON (${
+        error instanceof Error ? error.message : "parse error"
+      }). Pass a JSON object string, e.g. '{"img_brightness": 0}'. No settings were changed.`,
+    };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      message: `Invalid ${label}: expected a JSON object, received ${
+        Array.isArray(parsed) ? "an array" : String(parsed === null ? "null" : typeof parsed)
+      }. No settings were changed.`,
+    };
+  }
+
+  normalize?.(parsed as Record<string, unknown>);
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    return { ok: false, message: describeSettingsIssues(label, result.error, parsed) };
+  }
+  return { ok: true, value: result.data };
+}
 
 const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
   const {
@@ -60,49 +146,65 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
 
         // Parse and add video settings
         if (cameraVideoSettings && cameraVideoSettings.trim()) {
-          const videoSettings = JSON.parse(cameraVideoSettings);
-          // Validate with zod schema
-          const validatedVideo = CameraVideoSettings.parse(videoSettings);
+          const video = parseSettingsBlock(
+            "camera video settings",
+            cameraVideoSettings,
+            CameraVideoSettings
+          );
+          if (!video.ok) {
+            return errorResult(video.message);
+          }
           updatePayload.configUpdate.videoFacetSettings = {
-            [facet]: cleanUpdatePayload(validatedVideo),
+            [facet]: cleanUpdatePayload(video.value),
           };
         }
 
         // Parse and add audio settings
         if (cameraAudioSettings && cameraAudioSettings.trim()) {
-          const audioSettings = JSON.parse(cameraAudioSettings);
-          // Validate with zod schema
-          const validatedAudio = CameraAudioSettings.parse(audioSettings);
+          const audio = parseSettingsBlock(
+            "camera audio settings",
+            cameraAudioSettings,
+            CameraAudioSettings
+          );
+          if (!audio.ok) {
+            return errorResult(audio.message);
+          }
           updatePayload.configUpdate.audioFacetSettings = {
-            [facet]: cleanUpdatePayload(validatedAudio),
+            [facet]: cleanUpdatePayload(audio.value),
           };
         }
 
         // Parse and add device settings
         if (cameraDeviceSettings && cameraDeviceSettings.trim()) {
-          const deviceSettings = JSON.parse(cameraDeviceSettings);
-          logger.debug("[update-tool] Raw device settings:", deviceSettings);
+          const device = parseSettingsBlock(
+            "camera device settings",
+            cameraDeviceSettings,
+            CameraDeviceSettings,
+            deviceSettings => {
+              logger.debug("[update-tool] Raw device settings:", deviceSettings);
 
-          // Transform ledMode to led_mode and OFF to always_off before validation
-          if ("ledMode" in deviceSettings) {
-            deviceSettings.led_mode =
-              deviceSettings.ledMode === "OFF" ? "always_off" : deviceSettings.ledMode;
-            delete deviceSettings.ledMode;
+              // Transform ledMode to led_mode and OFF to always_off before validation
+              if ("ledMode" in deviceSettings) {
+                deviceSettings.led_mode =
+                  deviceSettings.ledMode === "OFF" ? "always_off" : deviceSettings.ledMode;
+                delete deviceSettings.ledMode;
+              }
+
+              // Convert string "true"/"false" to boolean for led_stealth_mode
+              if (
+                "led_stealth_mode" in deviceSettings &&
+                typeof deviceSettings.led_stealth_mode === "string"
+              ) {
+                deviceSettings.led_stealth_mode = deviceSettings.led_stealth_mode === "true";
+              }
+            }
+          );
+          if (!device.ok) {
+            return errorResult(device.message);
           }
+          logger.debug("[update-tool] Validated device settings:", device.value);
 
-          // Convert string "true"/"false" to boolean for led_stealth_mode
-          if (
-            "led_stealth_mode" in deviceSettings &&
-            typeof deviceSettings.led_stealth_mode === "string"
-          ) {
-            deviceSettings.led_stealth_mode = deviceSettings.led_stealth_mode === "true";
-          }
-
-          // Validate with zod schema
-          const validatedDevice = CameraDeviceSettings.parse(deviceSettings);
-          logger.debug("[update-tool] Validated device settings:", validatedDevice);
-
-          const cleaned = cleanUpdatePayload(validatedDevice);
+          const cleaned = cleanUpdatePayload(device.value);
           logger.debug("[update-tool] Cleaned device settings:", cleaned);
 
           updatePayload.configUpdate.deviceSettings = cleaned;
@@ -117,16 +219,10 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
           extra.sessionId
         );
         if (!featureValidation.canProceed) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text:
-                  featureValidation.error ||
-                  "This camera does not support one or more requested features.",
-              },
-            ],
-          };
+          return errorResult(
+            featureValidation.error ||
+              "This camera does not support one or more requested features."
+          );
         }
 
         // Apply the updates
@@ -141,14 +237,7 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
           const normalizedError = hasCapabilitySensitiveChange
             ? "This camera may not support one or more requested settings."
             : result.error;
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Failed to update camera settings: ${normalizedError}`,
-              },
-            ],
-          };
+          return errorResult(`Failed to update camera settings: ${normalizedError}`);
         }
 
         // Format the updated settings for display
@@ -173,16 +262,11 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
           structuredContent: jsonResultResponse,
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Error updating camera settings: ${
-                error instanceof Error ? error.message : "Unknown error"
-              }`,
-            },
-          ],
-        };
+        return errorResult(
+          `Error updating camera settings: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`
+        );
       }
     }
 
@@ -200,14 +284,9 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
         );
 
         if (!cameraDetails.success || !cameraDetails.data) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Failed to get camera details: ${cameraDetails.error || "Camera not found"}`,
-              },
-            ],
-          };
+          return errorResult(
+            `Failed to get camera details: ${cameraDetails.error || "Camera not found"}`
+          );
         }
 
         const camera = cameraDetails.data;
@@ -244,16 +323,11 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
           structuredContent: jsonResultResponse,
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Error retrieving camera details: ${
-                error instanceof Error ? error.message : "Unknown error"
-              }`,
-            },
-          ],
-        };
+        return errorResult(
+          `Error retrieving camera details: ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`
+        );
       }
     }
 
@@ -282,85 +356,50 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
 
   // Handle other entity types (future implementation)
   if (entityType === "climate-sensor") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: "Climate sensor updates are not yet implemented. Coming soon!",
-        },
-      ],
-    };
+    return unsupportedResult("Climate sensor updates are not yet implemented. Coming soon!");
   }
 
   if (entityType === "door-controller") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: "Door controller updates are not yet implemented. Coming soon!",
-        },
-      ],
-    };
+    return unsupportedResult("Door controller updates are not yet implemented. Coming soon!");
   }
 
   if (entityType === "environmental-gateway") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: "Environmental gateway updates are not yet implemented. Coming soon!",
-        },
-      ],
-    };
+    return unsupportedResult(
+      "Environmental gateway updates are not yet implemented. Coming soon!"
+    );
   }
 
   if (entityType === "audio-gateway") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: "Audio gateway updates are not yet fully implemented. Coming soon!",
-        },
-      ],
-    };
+    return unsupportedResult("Audio gateway updates are not yet fully implemented. Coming soon!");
   }
 
   if (entityType === "doorbell-camera") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: "Doorbell camera updates are not yet fully implemented. Coming soon!",
-        },
-      ],
-    };
+    return unsupportedResult(
+      "Doorbell camera updates are not yet fully implemented. Coming soon!"
+    );
   }
 
   if (entityType === "badge-reader") {
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: "Badge reader updates are not yet fully implemented. Coming soon!",
-        },
-      ],
-    };
+    return unsupportedResult("Badge reader updates are not yet fully implemented. Coming soon!");
   }
 
   // Step 0: Show initial form (no entityType provided)
+  const entityTypeFormResponse = {
+    needUserInput: true,
+    message:
+      "Welcome to the Rhombus entity update tool!\n\nWhat type of entity would you like to update?\n\n• **camera** - Update camera video, audio, or device settings\n• **climate-sensor** - Update climate sensor settings (coming soon)\n• **door-controller** - Update door controller settings (coming soon)\n• **environmental-gateway** - Update environmental gateway settings (coming soon)\n\nPlease specify the entity type to continue.",
+    requestType: "entity-type-selection",
+    submitAction: "update-tool",
+  };
+
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({
-          needUserInput: true,
-          message:
-            "Welcome to the Rhombus entity update tool!\n\nWhat type of entity would you like to update?\n\n• **camera** - Update camera video, audio, or device settings\n• **climate-sensor** - Update climate sensor settings (coming soon)\n• **door-controller** - Update door controller settings (coming soon)\n• **environmental-gateway** - Update environmental gateway settings (coming soon)\n\nPlease specify the entity type to continue.",
-          requestType: "entity-type-selection",
-          submitAction: "update-tool",
-        }),
+        text: JSON.stringify(entityTypeFormResponse),
       },
     ],
+    structuredContent: entityTypeFormResponse,
   };
 };
 

--- a/src/types/update-tool-types.ts
+++ b/src/types/update-tool-types.ts
@@ -110,21 +110,34 @@ export const TOOL_ARGS = {
     ),
 
   // Camera-specific update fields
+  // These three arrive as free-form JSON strings, so the field schemas below are
+  // NOT part of the input schema the model sees — this description text is the
+  // only range guidance it ever gets. Keep it in sync with CameraVideoSettings /
+  // CameraAudioSettings / CameraDeviceSettings.
+  //
+  // Promoting them to real object schemas would NOT make out-of-range values
+  // impossible: the chatbot sends MCP tools to OpenAI with `strict: false`
+  // (chatbot src/mcp/toolAdapters.ts), so there is no constrained decoding, and
+  // even under `strict: true` JSON Schema `minimum`/`maximum` are not enforced
+  // keywords. Range checking is therefore ALWAYS the tool's job — which is why
+  // parseSettingsBlock reports the field, the bound, and the received value.
   cameraVideoSettings: z
     .string()
     .nullable()
     .describe(
-      `JSON string of video settings to update for camera. Example for a dark image: '{"img_brightness": 0, "wdr_strength": 64}'; for a washed-out image: '{"img_brightness": -50, "img_contrast": 80}'. Saturation matters — 0 yields grayscale; most cameras look best mid-range, tune from there.`,
+      `JSON string of video settings to update for camera. Values outside these ranges are REJECTED — img_brightness: -255 to 255 · img_contrast: 0 to 128 · img_saturation: 0 to 255 · img_sharpness: 0 to 11 (6 is typical — NOT a 0-100 scale) · wdr_strength: 0 to 128 (64 is typical) · zero_motion_video_bitrate_percent: 0 to 100 · hdr_enabled / wdr_enabled / video_persist_disabled: booleans · resolution: {"width": n, "height": n}. The night-mode fields (night_img_brightness, night_img_contrast, night_img_saturation, night_img_sharpness) take the same ranges as their daytime counterparts. Example for a dark image: '{"img_brightness": 0, "wdr_strength": 64}'; for a washed-out image: '{"img_brightness": -50, "img_contrast": 80}'; for a blurry image: '{"img_sharpness": 8}'. Saturation matters — 0 yields grayscale; most cameras look best mid-range, tune from there.`,
     ),
   cameraAudioSettings: z
     .string()
     .nullable()
-    .describe("JSON string of audio settings to update for camera (recording, microphone, speaker)."),
+    .describe(
+      `JSON string of audio settings to update for camera. audio_record / device_mic_enabled / device_speaker_enabled: booleans · audio_internal_mic_volume: 0 to 100 · audio_internal_speaker_volume: 0 to 100. Example: '{"audio_record": true, "audio_internal_mic_volume": 80}'.`,
+    ),
   cameraDeviceSettings: z
     .string()
     .nullable()
     .describe(
-      `JSON string of device settings to update for camera (name, timezone, LED). LED control uses EXACTLY these underscore field names (not camelCase): LED off = '{"led_stealth_mode": true}' (recommended) or '{"led_mode": "always_off"}'; LED on = '{"led_stealth_mode": false}' or '{"led_mode": "always_on"}' or '{"led_mode": "auto"}'.`,
+      `JSON string of device settings to update for camera (name, timezone, LED). camera_name / camera_timezone: strings · led_intensity: 0 to 100 · led_mode: one of "auto", "always_on", "always_off" · led_stealth_mode: boolean. LED control uses EXACTLY these underscore field names (not camelCase): LED off = '{"led_stealth_mode": true}' (recommended) or '{"led_mode": "always_off"}'; LED on = '{"led_stealth_mode": false}' or '{"led_mode": "always_on"}' or '{"led_mode": "auto"}'.`,
     ),
 
   // Step tracking for multi-step updates

--- a/src/util.ts
+++ b/src/util.ts
@@ -83,10 +83,20 @@ export function getFilePathsInDirectory(dirPath: string): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns an object in the form expected by `server.tool`
+ * Returns an object in the form expected by `server.tool`, for the text-only
+ * results tools use to report a bad/missing argument.
+ *
+ * `isError` is REQUIRED here, not cosmetic. Every tool that calls this also
+ * registers an `outputSchema`, and the SDK's post-handler validation throws
+ * "MCP error -32602: ... no structured content was provided" for any result
+ * that lacks `structuredContent` — unless `isError` is set, which short-circuits
+ * that check (see validateToolOutput in @modelcontextprotocol/sdk server/mcp.js).
+ * Without it the -32602 REPLACES this text, so the model sees a protocol crash
+ * instead of "doorControllerUuid is required" and cannot correct its call.
  */
 export function createToolTextContent(content: string): CallToolResult {
   return {
+    isError: true,
     content: [
       {
         type: "text",

--- a/test/filtering-utils.test.ts
+++ b/test/filtering-utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   filterIncludedFields,
   applyFilterBy,
@@ -498,5 +501,70 @@ describe("applyGroupBy", () => {
     expect(projected.camerasGrouped).toBeDefined();
     expect(projected.camerasGrouped.groups["loc-a"]).toBe(3);
     expect(projected.camerasCount).toBe(4);
+  });
+});
+
+describe("createFilteringProxy — missing structuredContent backstop", () => {
+  /**
+   * The failure this guards against is invisible at the handler level: the
+   * handler returns readable text and only the SDK's post-handler validation
+   * turns it into -32602. So drive it through the real SDK.
+   */
+  async function callThroughProxy(result: unknown, opts: { outputSchema?: boolean } = {}) {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    createFilteringProxy(server).registerTool(
+      "forgetful-tool",
+      {
+        description: "a tool whose author forgot structuredContent",
+        inputSchema: {},
+        ...(opts.outputSchema === false ? {} : { outputSchema: { message: z.string().optional() } }),
+      },
+      async () => result as never
+    );
+
+    const client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      return await client.callTool({
+        name: "forgetful-tool",
+        arguments: { includeFields: null, filterBy: null, groupBy: null },
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }
+
+  it("preserves the tool's message instead of letting the SDK emit -32602", async () => {
+    const result = await callThroughProxy({
+      content: [{ type: "text", text: "doorControllerUuid is required." }],
+    });
+
+    const text = (result.content as { text: string }[])[0].text;
+    expect(text).toBe("doorControllerUuid is required.");
+    expect(text).not.toContain("-32602");
+    expect(result.isError).toBe(true);
+  });
+
+  it("leaves a well-formed result untouched", async () => {
+    const result = await callThroughProxy({
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: { message: "ok" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({ message: "ok" });
+  });
+
+  it("does not touch tools that register no outputSchema", async () => {
+    const result = await callThroughProxy(
+      { content: [{ type: "text", text: "plain success text" }] },
+      { outputSchema: false }
+    );
+
+    // No outputSchema means no validation to fail — flagging isError here would
+    // wrongly turn legitimate text results (the private MCP's pattern) into errors.
+    expect(result.isError).toBeFalsy();
   });
 });

--- a/test/tools/update-tool.output-validation.test.ts
+++ b/test/tools/update-tool.output-validation.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createTool } from "../../src/tools-console/update-tool.js";
+import { createFilteringProxy } from "../../src/filtering-utils.js";
+import * as network from "../../src/network/network.js";
+
+vi.mock("../../src/network/network.js", async importOriginal => {
+  const actual = await importOriginal<typeof network>();
+  return { ...actual, postApi: vi.fn() };
+});
+
+/**
+ * The proxy-injected args (`includeFields`, `filterBy`, `groupBy`) and every
+ * declared arg are `.nullable()`, so all keys have to be present — same as the
+ * wire calls the model makes.
+ */
+function withNulledArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    entityType: "camera",
+    entityUuid: null,
+    cameraVideoSettings: null,
+    cameraAudioSettings: null,
+    cameraDeviceSettings: null,
+    step: null,
+    includeFields: null,
+    filterBy: null,
+    groupBy: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Driven end-to-end through the real SDK, because the regression lives in the
+ * SDK's post-handler validation of `structuredContent` against the registered
+ * outputSchema, not in our own code paths. A handler-level test cannot see it:
+ * the handler returns a perfectly readable error message and only the SDK turns
+ * a result without `structuredContent` into `MCP error -32602`, discarding it.
+ */
+async function callUpdateTool(args: Record<string, unknown>) {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  createTool(createFilteringProxy(server));
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  try {
+    return await client.callTool({ name: "update-tool", arguments: args });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+function textOf(result: Awaited<ReturnType<typeof callUpdateTool>>): string {
+  return (result.content as { text: string }[]).map(item => item.text).join("\n");
+}
+
+const CAMERA_UUID = "4Toqs6naTbulCRen-RxAPA";
+
+describe("update-tool — error paths survive output validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The prod failure (2026-08-03): the model sent img_sharpness=20 against the
+  // 0..11 cap, the ZodError was returned without structuredContent, and the SDK
+  // replaced it with -32602. The user got "a system error"; the model retried
+  // byte-identical settings because it had nothing to correct.
+  it("reports the out-of-range field and bound instead of MCP error -32602", async () => {
+    const result = await callUpdateTool(
+      withNulledArgs({
+        entityUuid: `${CAMERA_UUID}.v0`,
+        cameraVideoSettings: JSON.stringify({ img_sharpness: 20, wdr_strength: 64 }),
+        step: "confirmation",
+        includeFields: ["success", "message", "updatedSettings"],
+      })
+    );
+
+    const text = textOf(result);
+    expect(text).not.toContain("-32602");
+    expect(text).not.toContain("no structured content was provided");
+
+    // Actionable: names the field, the bound, and the value received.
+    expect(text).toContain("img_sharpness");
+    expect(text).toContain("at most 11");
+    expect(text).toContain("20");
+
+    expect(result.isError).toBe(true);
+    // The message has to survive the caller's `includeFields` projection, or the
+    // model is back to an unexplained failure.
+    expect((result.structuredContent as { message?: string }).message).toContain("img_sharpness");
+
+    // Nothing was sent to the API — validation runs before any network call, so
+    // the "settings are unchanged" claim in the answer stays true.
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed settings JSON string with a readable message", async () => {
+    const result = await callUpdateTool(
+      withNulledArgs({
+        entityUuid: CAMERA_UUID,
+        cameraVideoSettings: "{img_brightness: 0",
+        step: "confirmation",
+      })
+    );
+
+    const text = textOf(result);
+    expect(text).not.toContain("-32602");
+    expect(text).toContain("not valid JSON");
+    expect(result.isError).toBe(true);
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the API's own failure message when the update call fails", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({
+      error: true,
+      errorMsg: "device is offline",
+    } as never);
+
+    const result = await callUpdateTool(
+      withNulledArgs({
+        entityUuid: `${CAMERA_UUID}.v0`,
+        cameraDeviceSettings: JSON.stringify({ camera_name: "Front Door" }),
+        step: "confirmation",
+      })
+    );
+
+    const text = textOf(result);
+    expect(text).not.toContain("-32602");
+    expect(text).toContain("device is offline");
+    expect(result.isError).toBe(true);
+  });
+
+  it("surfaces a camera-details lookup failure on the settings-form step", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({
+      error: true,
+      errorMsg: "camera not found",
+    } as never);
+
+    const result = await callUpdateTool(
+      withNulledArgs({ entityUuid: CAMERA_UUID, step: "settings-configuration" })
+    );
+
+    const text = textOf(result);
+    expect(text).not.toContain("-32602");
+    expect(text).toContain("camera not found");
+    expect(result.isError).toBe(true);
+  });
+
+  // "Coming soon" is an answer, not a transport failure: it must carry
+  // structuredContent to clear validation, but must NOT be flagged isError or
+  // the model narrates it as a broken tool.
+  it("returns the not-implemented message for other entity types without erroring", async () => {
+    const result = await callUpdateTool(withNulledArgs({ entityType: "badge-reader" }));
+
+    const text = textOf(result);
+    expect(text).not.toContain("-32602");
+    expect(text).toContain("not yet fully implemented");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns the entity-type form when no entityType is resolvable", async () => {
+    // `entityType` is required by the input schema, so the step-0 form is only
+    // reachable via an unhandled enum member — assert the shape directly.
+    const result = await callUpdateTool(withNulledArgs({ entityType: "climate-sensor" }));
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as { message?: string }).message).toContain("Climate sensor");
+  });
+
+  it("still applies a valid update and reports success", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({ error: false } as never);
+
+    const result = await callUpdateTool(
+      withNulledArgs({
+        entityUuid: `${CAMERA_UUID}.v0`,
+        cameraVideoSettings: JSON.stringify({ img_sharpness: 8, wdr_strength: 64 }),
+        step: "confirmation",
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    const structured = result.structuredContent as { success?: boolean; message?: string };
+    expect(structured.success).toBe(true);
+    expect(structured.message).toContain("updated successfully");
+    expect(textOf(result)).toContain("Sharpness: 8");
+  });
+
+  it("normalizes ledMode/led_stealth_mode before validating, as before", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({ error: false } as never);
+
+    const result = await callUpdateTool(
+      withNulledArgs({
+        entityUuid: CAMERA_UUID,
+        cameraDeviceSettings: JSON.stringify({ ledMode: "OFF", led_stealth_mode: "true" }),
+        step: "confirmation",
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    const sent = vi.mocked(network.postApi).mock.calls.find(
+      ([arg]) => (arg as { route: string }).route === "/camera/updateFacetedConfig"
+    );
+    expect((sent?.[0] as { body: any }).body.configUpdate.deviceSettings).toEqual({
+      led_mode: "always_off",
+      led_stealth_mode: true,
+    });
+  });
+});


### PR DESCRIPTION
`update-tool` had broken return paths when it catches an invalid payload, therefore causing the MCP client to receive fals information on why its arguments may be invalid.