### PR TITLE
Fix/create camera policy error handling

### DIFF
--- a/src/filtering-utils.ts
+++ b/src/filtering-utils.ts
@@ -727,48 +727,6 @@ function applyFilteringToResult(
 }
 
 /**
- * Backstop for the single most damaging tool-result mistake in this codebase: a
- * tool that registers an `outputSchema` but returns `{content: [...]}` with no
- * `structuredContent`. The SDK's validateToolOutput then throws
- *   "MCP error -32602: Tool <x> has an output schema but no structured content"
- * which REPLACES the tool's own text. Because these are almost always error
- * paths, the message the model needed ("img_sharpness must be at most 11",
- * "doorControllerUuid is required") is exactly what gets destroyed — the model
- * is left with an opaque protocol failure, retries identical args, and gives up.
- * That shipped to prod at least twice.
- *
- * Setting `isError` makes the SDK skip output validation entirely, so the text
- * survives. This is a safety net, NOT a license to skip `structuredContent` in
- * new tools: it can only flag the result as an error, so a legitimate non-error
- * text result must still carry its own `structuredContent` (see
- * `unsupportedResult` in update-tool.ts). Hence the warn — it means "fix the tool".
- */
-function backstopMissingStructuredContent(
-	// biome-ignore lint/suspicious/noExplicitAny: SDK CallToolResult shape
-	result: any,
-	toolName: string,
-	hasOutputSchema: boolean,
-	// biome-ignore lint/suspicious/noExplicitAny: SDK CallToolResult shape
-): any {
-	if (
-		!hasOutputSchema ||
-		!result ||
-		typeof result !== "object" ||
-		!("content" in result) ||
-		result.structuredContent ||
-		result.isError
-	) {
-		return result;
-	}
-	logger.warn(
-		`[filtering-proxy] ${toolName} returned no structuredContent despite registering an outputSchema; ` +
-			`flagging isError so the SDK does not replace the message with -32602. Fix the tool: ` +
-			`return structuredContent (or set isError) explicitly.`,
-	);
-	return { ...result, isError: true };
-}
-
-/**
  * Returns a Proxy over an McpServer that intercepts every `registerTool` call to:
  * 1. Inject `includeFields` and `filterBy` into the tool's inputSchema
  * 2. Append a description suffix explaining the filtering params
@@ -858,16 +816,12 @@ export function createFilteringProxy(
 				const wrappedHandler = async (args: any, extra: unknown) => {
 					const { includeFields, filterBy, groupBy, ...restArgs } = args;
 					const result = await handler(restArgs, extra);
-					return backstopMissingStructuredContent(
-						applyFilteringToResult(
-							result,
-							includeFields,
-							filterBy,
-							groupBy,
-							protectedFields,
-						),
-						name,
-						Boolean(config.outputSchema),
+					return applyFilteringToResult(
+						result,
+						includeFields,
+						filterBy,
+						groupBy,
+						protectedFields,
 					);
 				};
 

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -115,6 +115,59 @@ function redactUrlForLog(url: string): string {
   return url.replace(/([?&]_rs=)[^&]+/g, "$1<redacted>");
 }
 
+// The `status` string on a failed result is read by tools and relayed to the
+// model almost verbatim, so it has to be a short, readable sentence. It used to
+// be `JSON.stringify({body: <the entire request payload>, error: <raw text>})`,
+// which buried the one useful line in a copy of the request — and collapsed to
+// the literally useless "Request Error: {}" whenever the thrown value was an
+// Error (JSON.stringify of an Error yields "{}").
+const API_ERROR_DETAIL_LIMIT = 400;
+
+function truncateDetail(text: string): string {
+  return text.length > API_ERROR_DETAIL_LIMIT
+    ? `${text.slice(0, API_ERROR_DETAIL_LIMIT)}…`
+    : text;
+}
+
+/** Pull the human-readable message out of an api2 error body (JSON or plain text). */
+function extractApiErrorDetail(responseText: string): string {
+  const text = responseText.trim();
+  if (!text) return "";
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object") {
+      for (const key of ["errorMsg", "message", "error", "status", "detail"]) {
+        const value = (parsed as Record<string, unknown>)[key];
+        if (typeof value === "string" && value.trim()) return truncateDetail(value.trim());
+      }
+    }
+  } catch {
+    // not JSON — fall through to the raw text
+  }
+  return truncateDetail(text);
+}
+
+function describeHttpFailure(status: number, responseText: string): string {
+  const detail = extractApiErrorDetail(responseText);
+  return detail
+    ? `HTTP ${status}: ${detail}`
+    : `HTTP ${status} from the Rhombus API (the response body carried no error message)`;
+}
+
+/** JSON.stringify(new Error(...)) === "{}", so unwrap thrown values by hand. */
+function describeThrown(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = error.cause instanceof Error ? ` (cause: ${error.cause.message})` : "";
+    return `${error.name}: ${error.message}${cause}`;
+  }
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const serialized = JSON.stringify(error);
+    if (serialized && serialized !== "{}") return truncateDetail(serialized);
+  }
+  return String(error ?? "unknown error");
+}
+
 export async function postApi<T>({
   route,
   body,
@@ -150,7 +203,11 @@ export async function postApi<T>({
       body,
     });
     if (!response.ok) {
-      logger.debug(`❌ RESPONSE - ${response.ok} - ${response.status}`);
+      const responseText = await response.text().catch(() => "");
+      // The request body belongs in the log, not in the message the model reads.
+      logger.error(
+        `[POSTAPI] HTTP ${response.status} - ${redactUrlForLog(url)} - request: ${body} - response: ${truncateDetail(responseText)}`
+      );
       if (response.status === 401 || response.status === 403) {
         return {
           error: true,
@@ -158,11 +215,10 @@ export async function postApi<T>({
             "Sorry, I don't have permission to help with this request.  Consider upgrading my permissions by changing the role of the API Key I am using.",
         } as T & { error?: boolean; status?: string };
       }
-      throw {
-        body: JSON.parse(body),
-        error: await response.text(),
-      };
-      // throw new Error(`HTTP error! status: ${response.status}`);
+      return {
+        error: true,
+        status: describeHttpFailure(response.status, responseText),
+      } as T & { error?: boolean; status?: string };
     }
     const ret = await response.json();
     const jsonStr = JSON.stringify(ret);
@@ -170,11 +226,15 @@ export async function postApi<T>({
     logger.debug(`✅ RESPONSE - ${response.ok} - ${truncatedJson}`);
     return ret as T & { error?: boolean; status?: string };
   } catch (error) {
-    logger.error(`[POSTAPI] ERROR - ${JSON.stringify(error || {}, null, 4)}`);
+    logger.error(
+      `[POSTAPI] ERROR - ${redactUrlForLog(url)} - ${
+        error instanceof Error ? (error.stack ?? error.message) : describeThrown(error)
+      }`
+    );
 
     return {
       error: true,
-      status: `Request Error: ${JSON.stringify(error)}`,
+      status: `Request failed before a response was received: ${describeThrown(error)}`,
     } as T & { error?: boolean; status?: string };
   }
 }

--- a/src/tools-console/create-camera-policy-tool.ts
+++ b/src/tools-console/create-camera-policy-tool.ts
@@ -2,7 +2,15 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { RequestModifiers } from "../util.js";
 import { createCameraPolicy } from "../api/create-camera-policy-tool-api.js";
-import { ApiPayloadSchema, OUTPUT_SCHEMA } from "../types/create-camera-policy-tool-types.js";
+import {
+  ApiPayloadSchema,
+  OUTPUT_SCHEMA,
+  SCHEDULE_CONFIGS_EXAMPLE,
+  SUGGESTED_CAMERA_ACTIVITIES,
+  isEmptyScheduleConfigs,
+  parseCameraUuids,
+  parseScheduleConfigs,
+} from "../types/create-camera-policy-tool-types.js";
 import { postApi } from "../network/network.js";
 import type { schema } from "../types/schema.js";
 
@@ -13,6 +21,8 @@ A tool for creating a camera policy.
 Preferred (single call): pass name, description, orgUuid, scheduleConfigs, and cameraUuids together — the tool creates the policy, configures its schedule triggers, and assigns the cameras all in one call. Omit policyUuid; it is created for you.
 
 Legacy step-by-step: calling with only a subset of args advances one phase at a time (name/description/orgUuid to create → policyUuid+scheduleConfigs for schedules → policyUuid+cameraUuids for camera assignment).
+
+Errors are labelled: a "RETRYABLE" error means nothing was written and you should call again with corrected arguments; a "PARTIAL STATE" error means part of the policy now exists and you must stop and report it.
 `;
 
 // All args are optional: each step of the flow uses a different subset, and
@@ -25,11 +35,29 @@ const TOOL_ARGS = {
   orgUuid: z.string().optional().describe("Organization UUID (for creating policy)"),
 
   // Step 2: Schedule configuration
-  policyUuid: z.string().optional().describe("Policy UUID (for configuring schedules)"),
-  scheduleConfigs: z.string().optional().describe("JSON string of schedule configurations"),
+  policyUuid: z
+    .string()
+    .optional()
+    .describe(
+      "Policy UUID of an EXISTING policy (for configuring schedules or assigning cameras on an already-created policy). Omit it when creating a policy — including on a single full call that also passes scheduleConfigs and cameraUuids."
+    ),
+  scheduleConfigs: z
+    .string()
+    .optional()
+    .describe(
+      `JSON array string of schedule configurations: [{"scheduleUuid": <uuid>, "activities": [<activity>, ...]}]. ` +
+        `"activities" must be a real JSON array of activity strings, not a string containing an array, and each ` +
+        `value must be an API activity constant (e.g. ${SUGGESTED_CAMERA_ACTIVITIES.slice(0, 6).join(", ")}) — ` +
+        `never a display label like "Human Movement". Example: ${SCHEDULE_CONFIGS_EXAMPLE}`
+    ),
 
   // Step 3: Camera assignment
-  cameraUuids: z.string().optional().describe("Comma-separated camera UUIDs to assign policy to"),
+  cameraUuids: z
+    .string()
+    .optional()
+    .describe(
+      'Comma-separated camera UUIDs to assign policy to, e.g. "uuidA,uuidB". Camera uuids only — resolve names to uuids first.'
+    ),
   policyName: z.string().optional().describe("Policy name (for reference)"),
 } as const;
 
@@ -48,55 +76,99 @@ function errorResult(text: string) {
   };
 }
 
-// postApi returns {error: true, status: "..."} on 401/403 and domain errors
-// arrive as {error: true, errorMsg: "..."} — normalize both.
-function apiErrorText(result: { errorMsg?: string | null; status?: string | null }): string {
-  return result.errorMsg || result.status || "Unknown error";
+// Errors are labelled by whether anything was written, because the caller cannot
+// otherwise tell. The guided workflow says "on error, STOP and make no further
+// calls" — correct after a partial mutation (a retry would create a SECOND
+// policy) and wrong before one, where a corrected retry is free. Prod 2026-08-04:
+// a malformed `scheduleConfigs` was rejected before any write, the model stopped
+// and apologized, and the identical request succeeded when the user asked again.
+const RETRYABLE_PREFIX = "RETRYABLE — nothing was created or changed by this call.";
+const PARTIAL_PREFIX = "PARTIAL STATE — do NOT retry this call and do NOT create another policy.";
+const RETRY_INSTRUCTION =
+  "Fix the arguments named above, then call this tool ONCE more with corrected arguments. Do not tell the user the policy could not be created unless a corrected retry also fails.";
+
+function retryableError(detail: string) {
+  return errorResult(`${RETRYABLE_PREFIX} ${detail} ${RETRY_INSTRUCTION}`);
+}
+
+/** Retryable, but a policy from an earlier call already exists — don't re-create it. */
+function retryableStepError(detail: string, existingPolicyUuid: string) {
+  return errorResult(
+    `${RETRYABLE_PREFIX} Policy ${existingPolicyUuid} already exists from an earlier call — do NOT create another one. ${detail} ${RETRY_INSTRUCTION}`
+  );
+}
+
+function partialStateError(detail: string) {
+  return errorResult(`${PARTIAL_PREFIX} ${detail} Report exactly this state to the user.`);
+}
+
+// postApi returns {error: true, status: "..."} on transport/HTTP failures and
+// domain errors arrive as {error: true, errorMsg: "..."} — normalize both.
+function apiErrorText(result: {
+  errorMsg?: string | null;
+  status?: string | null;
+}): string {
+  return (
+    result.errorMsg?.trim() ||
+    result.status?.trim() ||
+    "the Rhombus API reported a failure without a message"
+  );
+}
+
+/** api2 can succeed while reporting a caveat; dropping it hides real problems. */
+function apiWarningSuffix(result: { warningMsg?: string | null }): string {
+  const warning = result.warningMsg?.trim();
+  return warning ? ` Note from the API: ${warning}` : "";
 }
 
 const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
   const { name, description, orgUuid, policyUuid, scheduleConfigs, cameraUuids, policyName } = args;
+
+  // An empty list is how the legacy step-1 call spells "no schedules yet", so it
+  // must not select the schedule phase. Detected by parsing, not by comparing to
+  // the literal "[]" — "[ ]" and "\"[]\"" used to slip past that compare and
+  // fall through into policy creation, silently creating a DUPLICATE policy.
+  const hasScheduleConfigs = Boolean(
+    scheduleConfigs?.trim() && !isEmptyScheduleConfigs(scheduleConfigs)
+  );
+  const hasFullInputSet = Boolean(name?.trim() && hasScheduleConfigs && cameraUuids?.trim());
+
+  // A full input set PLUS a policyUuid is ambiguous: create everything, or treat
+  // the uuid as an existing policy? It used to silently fall through to
+  // camera-assignment-only and then report "setup completely finished" for a
+  // policy whose schedules were never configured.
+  if (hasFullInputSet && policyUuid?.trim()) {
+    return retryableError(
+      `Ambiguous arguments: name, scheduleConfigs, and cameraUuids were all provided (a full creation call) together with policyUuid "${policyUuid.trim()}". ` +
+        `To create a new policy, drop policyUuid. To modify the existing policy ${policyUuid.trim()}, drop name and send policyUuid with ONE of scheduleConfigs or cameraUuids.`
+    );
+  }
 
   // Full run: all inputs present and no pre-existing policyUuid — create the
   // policy, configure schedules, and assign cameras in ONE call. The guided
   // workflow collects everything before confirming, and executing across three
   // model round trips proved fragile: the model wobbles at each call boundary
   // (re-renders forms, splits args wrong), so the boundaries are removed.
-  if (
-    name?.trim() &&
-    scheduleConfigs?.trim() &&
-    scheduleConfigs.trim() !== "[]" &&
-    cameraUuids?.trim() &&
-    !policyUuid?.trim()
-  ) {
-    // Validate both structured inputs BEFORE any mutation.
-    let scheduledTriggers: Array<{ scheduleUuid: string; triggerSet: Array<{ activity: string }> }>;
-    try {
-      const configs = JSON.parse(scheduleConfigs) as Array<{
-        scheduleUuid: string;
-        activities: string[];
-      }>;
-      scheduledTriggers = configs.map(config => ({
-        scheduleUuid: config.scheduleUuid,
-        triggerSet: config.activities.map(activity => ({ activity })),
-      }));
-    } catch (error) {
-      return errorResult(
-        `scheduleConfigs is not valid JSON (${error instanceof Error ? error.message : "Unknown error"}). Nothing was created — fix scheduleConfigs and retry.`
-      );
+  if (hasFullInputSet) {
+    // Validate BOTH structured inputs BEFORE any mutation, so anything wrong
+    // with them is a clean retryable failure rather than a half-built policy.
+    const parsedConfigs = parseScheduleConfigs(scheduleConfigs!);
+    if (!parsedConfigs.ok) {
+      return retryableError(parsedConfigs.message);
     }
-    const cameraList = cameraUuids
-      .split(",")
-      .map((uuid: string) => uuid.trim())
-      .filter((uuid: string) => uuid);
-    if (scheduledTriggers.length === 0 || cameraList.length === 0) {
-      return errorResult(
-        `scheduleConfigs and cameraUuids must both be non-empty for a full-run call. Nothing was created.`
-      );
+    const parsedCameras = parseCameraUuids(cameraUuids!);
+    if (!parsedCameras.ok) {
+      return retryableError(parsedCameras.message);
     }
+    const scheduledTriggers = parsedConfigs.value.map(config => ({
+      scheduleUuid: config.scheduleUuid,
+      triggerSet: config.activities.map(activity => ({ activity })),
+    }));
+    const cameraList = parsedCameras.value;
 
     // Phase 1: create.
     let createdUuid: string;
+    let createWarning = "";
     try {
       const payload = ApiPayloadSchema.parse({
         policy: {
@@ -112,19 +184,16 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
         extra.sessionId
       );
       if (result.error) {
-        return errorResult(
-          `Failed to create camera policy: ${apiErrorText(result)}. Nothing was created — report this failure to the user; do not claim any part succeeded.`
-        );
+        return retryableError(`Creating the policy failed: ${apiErrorText(result)}.`);
       }
       if (!result.policyUuid) {
-        return errorResult(
-          `Policy creation returned no policyUuid — treat this as a failure. Nothing was created — report this to the user.`
-        );
+        return retryableError("Creating the policy returned no policyUuid, so it did not succeed.");
       }
       createdUuid = result.policyUuid;
+      createWarning = apiWarningSuffix(result);
     } catch (error) {
-      return errorResult(
-        `Error creating camera policy: ${error instanceof Error ? error.message : "Unknown error"}. Nothing was created — report this failure to the user.`
+      return retryableError(
+        `Creating the policy failed: ${error instanceof Error ? error.message : "Unknown error"}.`
       );
     }
 
@@ -145,19 +214,25 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
         sessionId: extra.sessionId,
       });
       if (result.error) {
-        return errorResult(
-          `Policy "${name}" was created (uuid ${createdUuid}) but configuring its schedules failed: ${apiErrorText(result)}. No cameras were assigned. Report exactly this partial state to the user.`
+        return partialStateError(
+          `Policy "${name}" was created (uuid ${createdUuid}) but configuring its schedules failed: ${apiErrorText(result)}. No cameras were assigned.`
         );
       }
+      createWarning += apiWarningSuffix(result);
     } catch (error) {
-      return errorResult(
-        `Policy "${name}" was created (uuid ${createdUuid}) but configuring its schedules failed: ${error instanceof Error ? error.message : "Unknown error"}. No cameras were assigned. Report exactly this partial state to the user.`
+      return partialStateError(
+        `Policy "${name}" was created (uuid ${createdUuid}) but configuring its schedules failed: ${error instanceof Error ? error.message : "Unknown error"}. No cameras were assigned.`
       );
     }
 
     // Phase 3: cameras.
     try {
-      const result = await postApi<{ error?: boolean; errorMsg?: string; status?: string }>({
+      const result = await postApi<{
+        error?: boolean;
+        errorMsg?: string;
+        status?: string;
+        warningMsg?: string;
+      }>({
         route: "/camera/updateDetailsBulkV2",
         body: {
           cameraBulkDetails: cameraList.map(cameraUuid => ({
@@ -170,19 +245,20 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
         sessionId: extra.sessionId,
       });
       if (result?.error) {
-        return errorResult(
-          `Policy "${name}" was created with its schedules (uuid ${createdUuid}) but camera assignment failed: ${apiErrorText(result)}. Report exactly this partial state to the user.`
+        return partialStateError(
+          `Policy "${name}" was created with its schedules (uuid ${createdUuid}) but camera assignment failed: ${apiErrorText(result)}.`
         );
       }
+      createWarning += apiWarningSuffix(result);
     } catch (error) {
-      return errorResult(
-        `Policy "${name}" was created with its schedules (uuid ${createdUuid}) but camera assignment failed: ${error instanceof Error ? error.message : "Unknown error"}. Report exactly this partial state to the user.`
+      return partialStateError(
+        `Policy "${name}" was created with its schedules (uuid ${createdUuid}) but camera assignment failed: ${error instanceof Error ? error.message : "Unknown error"}.`
       );
     }
 
     const fullRunResponse = {
       needUserInput: false,
-      message: `Policy "${name}" created with ${scheduledTriggers.length} schedule trigger(s) and assigned to ${cameraList.length} camera(s).`,
+      message: `Policy "${name}" created with ${scheduledTriggers.length} schedule trigger(s) and assigned to ${cameraList.length} camera(s).${createWarning}`,
       policyUuid: createdUuid,
       policyName: name,
     };
@@ -190,7 +266,7 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
       content: [
         {
           type: "text" as const,
-          text: `🎉 Camera policy setup completely finished!\n\n✅ Policy "${name}" created with ${scheduledTriggers.length} schedule trigger(s)\n✅ Assigned to ${cameraList.length} camera(s)\n✅ Policy is now fully active`,
+          text: `🎉 Camera policy setup completely finished!\n\n✅ Policy "${name}" created with ${scheduledTriggers.length} schedule trigger(s)\n✅ Assigned to ${cameraList.length} camera(s)\n✅ Policy is now fully active${createWarning}`,
         },
       ],
       structuredContent: fullRunResponse,
@@ -203,136 +279,150 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
     // policyUuid: "" with policyUuidUpdated: true to every listed camera —
     // i.e. UNASSIGN their existing policies, not assign the new one.
     if (!policyUuid?.trim()) {
-      return errorResult(
-        `Cannot assign cameras: policyUuid is empty. The policy has not been created (or its creation failed). Either pass the full set (name, scheduleConfigs, cameraUuids) in one call to create everything at once, or create the policy first (name/description/orgUuid call) and pass the returned policyUuid.`
+      return retryableError(
+        `Cannot assign cameras: policyUuid is empty, so the policy has not been created yet. ` +
+          `Either pass the full set (name, scheduleConfigs, cameraUuids) in one call to create everything at once, or create the policy first (name/description/orgUuid call) and pass the returned policyUuid.`
       );
     }
-    try {
-      const cameraList = cameraUuids
-        .split(",")
-        .map((uuid: string) => uuid.trim())
-        .filter((uuid: string) => uuid);
 
-      if (cameraList.length > 0) {
-        const cameraPayload = {
+    const parsedCameras = parseCameraUuids(cameraUuids);
+    if (!parsedCameras.ok) {
+      // Previously an unusable cameraUuids string (e.g. ",") left this branch
+      // with no return at all and fell through into policy creation, creating a
+      // duplicate policy and reporting success.
+      return retryableStepError(parsedCameras.message, policyUuid.trim());
+    }
+    const cameraList = parsedCameras.value;
+
+    try {
+      const result = await postApi<{
+        error?: boolean;
+        errorMsg?: string;
+        status?: string;
+        warningMsg?: string;
+      }>({
+        route: "/camera/updateDetailsBulkV2",
+        body: {
           cameraBulkDetails: cameraList.map(cameraUuid => ({
             uuid: cameraUuid,
             policyUuid: policyUuid,
             policyUuidUpdated: true,
           })),
-        };
-
-        const result = await postApi<{ error?: boolean; errorMsg?: string; status?: string }>({
-          route: "/camera/updateDetailsBulkV2",
-          body: cameraPayload,
-          modifiers: extra._meta?.requestModifiers as RequestModifiers,
-          sessionId: extra.sessionId,
-        });
-        if (result?.error) {
-          return errorResult(
-            `Failed to assign policy to cameras: ${apiErrorText(result)}. The policy was NOT assigned — report this failure to the user; do not claim success.`
-          );
-        }
-        const jsonResultResponse = {
-          needUserInput: false,
-          message: `Excellent! Policy created and assigned to ${cameraList.length} camera(s)!`,
-          policyUuid,
-          policyName,
-        };
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `🎉 Camera policy setup completely finished!\n\n✅ Policy "${policyName?.trim() || policyUuid}" assigned to ${cameraList.length} camera(s)\n✅ Policy is now fully active\n\nYour cameras will now generate alerts according to the policy configuration.`,
-            },
-          ],
-          structuredContent: jsonResultResponse,
-        };
+        },
+        modifiers: extra._meta?.requestModifiers as RequestModifiers,
+        sessionId: extra.sessionId,
+      });
+      if (result?.error) {
+        // Assigning cameras is idempotent, so a corrected retry is safe — but
+        // the policy itself already exists and must not be created again.
+        return retryableStepError(
+          `Assigning the policy to the cameras failed: ${apiErrorText(result)}.`,
+          policyUuid
+        );
       }
+      const warning = apiWarningSuffix(result);
+      const jsonResultResponse = {
+        needUserInput: false,
+        message: `Policy "${policyName?.trim() || policyUuid}" assigned to ${cameraList.length} camera(s).${warning}`,
+        policyUuid,
+        policyName,
+      };
+      return {
+        content: [
+          {
+            type: "text" as const,
+            // Claims only what THIS call did: schedules may or may not have been
+            // configured by an earlier call, and this branch cannot know.
+            text: `✅ Policy "${policyName?.trim() || policyUuid}" assigned to ${cameraList.length} camera(s).${warning}`,
+          },
+        ],
+        structuredContent: jsonResultResponse,
+      };
     } catch (error) {
-      return errorResult(
-        `Failed to assign policy to cameras: ${error instanceof Error ? error.message : "Unknown error"}. The policy was NOT assigned — report this failure to the user; do not claim success.`
+      return retryableStepError(
+        `Assigning the policy to the cameras failed: ${error instanceof Error ? error.message : "Unknown error"}.`,
+        policyUuid
       );
     }
   }
 
   // Step 2: Schedule configuration (if scheduleConfigs provided and non-empty)
-  if (scheduleConfigs?.trim() && scheduleConfigs.trim() !== "[]") {
+  if (hasScheduleConfigs) {
     if (!policyUuid?.trim()) {
-      return errorResult(
-        `Cannot configure schedules: policyUuid is empty. Create the policy first (name/description/orgUuid call) and pass the returned policyUuid. Do NOT combine creation, schedule, and camera args in one call — the steps run one at a time.`
+      return retryableError(
+        `Cannot configure schedules: policyUuid is empty. Create the policy first (name/description/orgUuid call) and pass the returned policyUuid, or pass the full set (name, scheduleConfigs, cameraUuids) in one call to do everything at once.`
       );
     }
+
+    const parsedConfigs = parseScheduleConfigs(scheduleConfigs!);
+    if (!parsedConfigs.ok) {
+      return retryableStepError(parsedConfigs.message, policyUuid.trim());
+    }
+    const scheduledTriggers = parsedConfigs.value.map(config => ({
+      scheduleUuid: config.scheduleUuid,
+      triggerSet: config.activities.map(activity => ({ activity })),
+    }));
+
+    // /policy/updateCameraPolicy has REPLACE semantics: any field omitted
+    // from the policy object is NULLED on the stored policy. Sending only
+    // {uuid, scheduledTriggers} erases the name/description that step 1
+    // just set (observed in ITG: wizard-created policies with name: null,
+    // invisible in the Console). Always resend the identity fields.
+    const effectiveName = policyName?.trim() || name?.trim();
+    if (!effectiveName) {
+      return retryableStepError(
+        `Cannot configure schedules: policyName is required — updateCameraPolicy replaces the whole policy object, so omitting the name would erase it. Pass policyName (and description, if any) along with policyUuid and scheduleConfigs.`,
+        policyUuid.trim()
+      );
+    }
+
     try {
-      const configs = JSON.parse(scheduleConfigs) as Array<{
-        scheduleUuid: string;
-        activities: string[];
-      }>;
-
-      // Only proceed if we have actual schedule configurations
-      if (configs.length > 0) {
-        const scheduledTriggers = configs.map(config => ({
-          scheduleUuid: config.scheduleUuid,
-          triggerSet: config.activities.map(activity => ({ activity })),
-        }));
-
-        // /policy/updateCameraPolicy has REPLACE semantics: any field omitted
-        // from the policy object is NULLED on the stored policy. Sending only
-        // {uuid, scheduledTriggers} erases the name/description that step 1
-        // just set (observed in ITG: wizard-created policies with name: null,
-        // invisible in the Console). Always resend the identity fields.
-        const effectiveName = policyName?.trim() || name?.trim();
-        if (!effectiveName) {
-          return errorResult(
-            `Cannot configure schedules: policyName is required — updateCameraPolicy replaces the whole policy object, so omitting the name would erase it. Pass policyName (and description, if any) along with policyUuid and scheduleConfigs.`
-          );
-        }
-        const payload = {
+      const result = await postApi<schema["Policy_UpdateCameraPolicyWSResponse"]>({
+        route: "/policy/updateCameraPolicy",
+        body: {
           policy: {
             uuid: policyUuid,
             name: effectiveName,
             description: description?.trim() ? description : undefined,
             scheduledTriggers,
           },
-        };
+        },
+        modifiers: extra._meta?.requestModifiers as RequestModifiers,
+        sessionId: extra.sessionId,
+      });
 
-        const result = await postApi<schema["Policy_UpdateCameraPolicyWSResponse"]>({
-          route: "/policy/updateCameraPolicy",
-          body: payload,
-          modifiers: extra._meta?.requestModifiers as RequestModifiers,
-          sessionId: extra.sessionId,
-        });
-
-        if (result.error) {
-          return errorResult(
-            `Failed to configure policy schedules: ${apiErrorText(result)}. The schedules were NOT configured — report this failure to the user; do not claim success.`
-          );
-        }
-
-        // Neutral, fact-only message: imperative text like "Please select
-        // which cameras..." is an instruction the model follows over the
-        // workflow playbook (observed: it re-rendered the confirm form or
-        // stopped mid-execution to ask for cameras it already had).
-        const jsonResultResponse = {
-          needUserInput: false,
-          message: `Schedules configured for policy "${effectiveName}" (${policyUuid}).`,
-          policyUuid,
-          policyName,
-        };
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(jsonResultResponse),
-            },
-          ],
-          structuredContent: jsonResultResponse,
-        };
+      if (result.error) {
+        // Replacing the schedules is idempotent — safe to retry, as long as the
+        // policy is not created a second time.
+        return retryableStepError(
+          `Configuring the policy schedules failed: ${apiErrorText(result)}.`,
+          policyUuid
+        );
       }
-      // If configs.length === 0, fall through to policy creation
+
+      // Neutral, fact-only message: imperative text like "Please select
+      // which cameras..." is an instruction the model follows over the
+      // workflow playbook (observed: it re-rendered the confirm form or
+      // stopped mid-execution to ask for cameras it already had).
+      const jsonResultResponse = {
+        needUserInput: false,
+        message: `Schedules configured for policy "${effectiveName}" (${policyUuid}).${apiWarningSuffix(result)}`,
+        policyUuid,
+        policyName,
+      };
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(jsonResultResponse),
+          },
+        ],
+        structuredContent: jsonResultResponse,
+      };
     } catch (error) {
-      return errorResult(
-        `Error configuring schedules: ${error instanceof Error ? error.message : "Unknown error"}. The schedules were NOT configured — report this failure to the user; do not claim success.`
+      return retryableStepError(
+        `Configuring the policy schedules failed: ${error instanceof Error ? error.message : "Unknown error"}.`,
+        policyUuid
       );
     }
   }
@@ -356,14 +446,10 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
       );
 
       if (result.error) {
-        return errorResult(
-          `Failed to create camera policy: ${apiErrorText(result)}. The policy was NOT created — report this failure to the user and stop the workflow; do not proceed to schedules or cameras.`
-        );
+        return retryableError(`Creating the policy failed: ${apiErrorText(result)}.`);
       }
       if (!result.policyUuid) {
-        return errorResult(
-          `Policy creation returned no policyUuid — treat this as a failure. Report it to the user and stop the workflow; do not proceed to schedules or cameras.`
-        );
+        return retryableError("Creating the policy returned no policyUuid, so it did not succeed.");
       }
       console.error(
         `[createCameraPolicyTool] -- Policy created. Got result ${JSON.stringify(result)}`
@@ -371,7 +457,7 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
       // Neutral, fact-only message (see the schedule-step comment above).
       const jsonResultResponse = {
         needUserInput: false,
-        message: `Policy "${name}" created with UUID: ${result.policyUuid}`,
+        message: `Policy "${name}" created with UUID: ${result.policyUuid}${apiWarningSuffix(result)}`,
         policyUuid: result.policyUuid,
         policyName: name,
       };
@@ -385,8 +471,8 @@ const TOOL_HANDLER = async (args: ToolArgs, extra: any) => {
         structuredContent: jsonResultResponse,
       };
     } catch (error) {
-      return errorResult(
-        `Error creating camera policy: ${error instanceof Error ? error.message : "Unknown error"}. The policy was NOT created — report this failure to the user and stop the workflow.`
+      return retryableError(
+        `Creating the policy failed: ${error instanceof Error ? error.message : "Unknown error"}.`
       );
     }
   }

--- a/src/types/create-camera-policy-tool-types.ts
+++ b/src/types/create-camera-policy-tool-types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { schemas } from "./zod-schemas.js";
+import { ActivityEnum } from "./schema.js";
 
 export const ApiPayloadSchema = schemas.Policy_CreateCameraPolicyWSRequest;
 export type ApiPayload = z.infer<typeof ApiPayloadSchema>;
@@ -21,3 +22,309 @@ export const OUTPUT_SCHEMA = z.object({
     .optional()
     .describe("The name of the policy that was created during this workflow"),
 });
+
+// ---------------------------------------------------------------------------
+// scheduleConfigs / cameraUuids parsing
+//
+// Both are free-form STRING params, so nothing machine-enforces their shape:
+// tools are adapted for OpenAI with `strict: false`, and even under `strict:
+// true` a string param's *contents* are never constrained. Every check has to
+// live here, and every message has to name the field, the expected shape, and
+// what was actually received — otherwise the model has nothing to correct and
+// reports the whole workflow as broken (prod 2026-08-04).
+// ---------------------------------------------------------------------------
+
+/**
+ * The activities the camera-policy workflow offers. This is a curated, camera-
+ * relevant subset of the API's org-wide `ActivityEnum` — it is what we suggest,
+ * NOT what we accept (validation goes against the full enum below, so a
+ * legitimate activity the playbook happens not to list still works).
+ *
+ * Keep in sync with the option list in the private MCP's
+ * `workflows/create-camera-policy.ts` playbook.
+ */
+export const SUGGESTED_CAMERA_ACTIVITIES = [
+  "MOTION",
+  "MOTION_HUMAN",
+  "MOTION_CAR",
+  "MOTION_ANIMAL",
+  "FACE_ALERT",
+  "FACE_UNIDENTIFIED",
+  "LICENSEPLATE_ALERT",
+  "HUMAN_ENTER",
+  "HUMAN_EXIT",
+  "CAR_ENTER",
+  "CAR_EXIT",
+  "POSE_ANOMALOUS",
+  "POSE_FALL",
+  "HELMET_MISSING",
+  "MASK_MISSING",
+  "GLOVES_MISSING",
+  "VISUAL_TAMPER",
+  "TAMPER",
+  "PEOPLECOUNT_HIGH",
+] as const;
+
+const VALID_ACTIVITIES = new Set<string>(Object.values(ActivityEnum) as string[]);
+
+export const SCHEDULE_CONFIGS_EXAMPLE =
+  '[{"scheduleUuid":"Wq1nR0kBS9y_2hZpVvGkAA","activities":["MOTION_HUMAN","MOTION_CAR"]}]';
+
+const SHAPE_HINT =
+  `Expected a JSON array string of objects, each with a "scheduleUuid" string and an "activities" ` +
+  `array of activity strings — e.g. ${SCHEDULE_CONFIGS_EXAMPLE}. "activities" must be a real JSON ` +
+  `array, NOT a string containing one.`;
+
+// Rhombus uuids are 22-char base64url. Deliberately loose — this only has to
+// catch the model passing a human-readable NAME ("Business Hours", "Front Door")
+// where a uuid belongs, which otherwise reaches the API and fails there, after
+// the policy has already been created.
+const UUID_LIKE = /^[A-Za-z0-9_-]{10,64}$/;
+
+export type ScheduleConfig = { scheduleUuid: string; activities: string[] };
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; message: string };
+
+function quote(value: unknown): string {
+  const serialized = typeof value === "string" ? value : JSON.stringify(value);
+  const text = serialized ?? String(value);
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text;
+}
+
+/**
+ * Accept every unambiguous spelling of "a list of activities" the model
+ * produces, and return null only when the value cannot be read as one.
+ * Tolerated: a real array; a JSON-encoded array (the playbook tells the model to
+ * JSON-encode structured values into the form context, and it then re-embeds the
+ * encoded string); a comma-separated string; the API's own
+ * `[{activity: "..."}]` trigger shape.
+ */
+function coerceActivities(raw: unknown): string[] | null {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith("[")) {
+      try {
+        return coerceActivities(JSON.parse(trimmed));
+      } catch {
+        return null;
+      }
+    }
+    return trimmed
+      .split(",")
+      .map(part => part.trim())
+      .filter(Boolean);
+  }
+  if (Array.isArray(raw)) {
+    const out: string[] = [];
+    for (const item of raw) {
+      if (typeof item === "string") {
+        if (item.trim()) out.push(item.trim());
+        continue;
+      }
+      if (item && typeof item === "object") {
+        const activity = (item as Record<string, unknown>).activity;
+        if (typeof activity === "string" && activity.trim()) {
+          out.push(activity.trim());
+          continue;
+        }
+      }
+      return null;
+    }
+    return out;
+  }
+  return null;
+}
+
+function normalizeActivity(activity: string): string {
+  return activity.trim().toUpperCase().replace(/[\s-]+/g, "_");
+}
+
+/**
+ * Parse the `scheduleConfigs` JSON string into the trigger configs. Runs BEFORE
+ * any mutation so every failure here is safely retryable.
+ */
+export function parseScheduleConfigs(raw: string): ParseResult<ScheduleConfig[]> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        `scheduleConfigs is not valid JSON (${error instanceof Error ? error.message : "parse error"}). ` +
+        SHAPE_HINT,
+    };
+  }
+
+  // Unwrap double (or triple) encoding rather than failing on it.
+  let unwrapAttempts = 0;
+  while (typeof parsed === "string" && unwrapAttempts < 3) {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return {
+        ok: false,
+        message: `scheduleConfigs decoded to a plain string ("${quote(parsed)}") rather than an array. ${SHAPE_HINT}`,
+      };
+    }
+    unwrapAttempts++;
+  }
+
+  if (parsed === null || typeof parsed !== "object") {
+    return {
+      ok: false,
+      message: `scheduleConfigs must be a JSON array; received ${parsed === null ? "null" : `a ${typeof parsed}`} (${quote(raw)}). ${SHAPE_HINT}`,
+    };
+  }
+
+  // A single config object instead of a one-element array is unambiguous.
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+
+  const configs: ScheduleConfig[] = [];
+  const issues: string[] = [];
+
+  entries.forEach((entry, index) => {
+    const label = `scheduleConfigs[${index}]`;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      issues.push(`${label} is not an object (received ${quote(entry)})`);
+      return;
+    }
+    const fields = entry as Record<string, unknown>;
+
+    const scheduleUuidRaw = fields.scheduleUuid ?? fields.uuid ?? fields.schedule;
+    if (typeof scheduleUuidRaw !== "string" || !scheduleUuidRaw.trim()) {
+      issues.push(
+        `${label}.scheduleUuid is missing or not a string (received ${quote(scheduleUuidRaw)})`
+      );
+      return;
+    }
+    const scheduleUuid = scheduleUuidRaw.trim();
+    if (!UUID_LIKE.test(scheduleUuid)) {
+      issues.push(
+        `${label}.scheduleUuid "${scheduleUuid}" is not a UUID — pass the schedule's uuid, not its name`
+      );
+      return;
+    }
+
+    const activitiesRaw = fields.activities ?? fields.activity ?? fields.triggerSet;
+    const activities = coerceActivities(activitiesRaw);
+    if (activities === null) {
+      issues.push(
+        `${label}.activities must be an array of activity strings (received ${quote(activitiesRaw)})`
+      );
+      return;
+    }
+    if (activities.length === 0) {
+      issues.push(`${label}.activities is empty — include at least one activity`);
+      return;
+    }
+
+    const normalized = activities.map(normalizeActivity);
+    const unsupported = normalized.filter(activity => !VALID_ACTIVITIES.has(activity));
+    if (unsupported.length > 0) {
+      issues.push(
+        `${label}.activities contains ${unsupported.length === 1 ? "an unsupported value" : "unsupported values"} ` +
+          `${unsupported.map(value => `"${value}"`).join(", ")} — supported camera activities are ` +
+          `${SUGGESTED_CAMERA_ACTIVITIES.join(", ")}`
+      );
+      return;
+    }
+
+    configs.push({ scheduleUuid, activities: normalized });
+  });
+
+  if (issues.length > 0) {
+    return { ok: false, message: `Invalid scheduleConfigs: ${issues.join("; ")}.` };
+  }
+  return { ok: true, value: configs };
+}
+
+/**
+ * True when `scheduleConfigs` is present but carries no configs — the legacy
+ * step-1 call passes an empty list, and the old `!== "[]"` string compare missed
+ * every other spelling of empty ("[ ]", "[\n]", "\"[]\""), which fell through
+ * into policy creation and could create a DUPLICATE policy.
+ */
+export function isEmptyScheduleConfigs(raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  let unwrapAttempts = 0;
+  while (typeof parsed === "string" && unwrapAttempts < 3) {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return false;
+    }
+    unwrapAttempts++;
+  }
+  return Array.isArray(parsed) && parsed.length === 0;
+}
+
+/**
+ * Parse `cameraUuids` (comma-separated, or a JSON array the model encoded
+ * instead) into a uuid list. Runs BEFORE any mutation, for the same reason as
+ * the schedule configs: an unparsed camera NAME reaches the API and fails only
+ * after the policy exists, leaving a half-built policy behind.
+ */
+export function parseCameraUuids(raw: string): ParseResult<string[]> {
+  let values: string[];
+  const trimmed = raw.trim();
+
+  if (trimmed.startsWith("[") || trimmed.startsWith('"[')) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return {
+        ok: false,
+        message: `cameraUuids looks like a JSON array but is not valid JSON (${quote(raw)}). Pass a comma-separated list of camera uuids, e.g. "uuidA,uuidB".`,
+      };
+    }
+    let unwrapAttempts = 0;
+    while (typeof parsed === "string" && unwrapAttempts < 3) {
+      try {
+        parsed = JSON.parse(parsed);
+      } catch {
+        break;
+      }
+      unwrapAttempts++;
+    }
+    if (!Array.isArray(parsed) || parsed.some(item => typeof item !== "string")) {
+      return {
+        ok: false,
+        message: `cameraUuids must be a comma-separated list of camera uuids, e.g. "uuidA,uuidB" (received ${quote(raw)}).`,
+      };
+    }
+    values = (parsed as string[]).map(value => value.trim()).filter(Boolean);
+  } else {
+    values = trimmed
+      .split(",")
+      .map(value => value.trim())
+      .filter(Boolean);
+  }
+
+  if (values.length === 0) {
+    return {
+      ok: false,
+      message: `cameraUuids contained no camera uuids (received ${quote(raw)}). Pass a comma-separated list of camera uuids, e.g. "uuidA,uuidB".`,
+    };
+  }
+
+  const invalid = values.filter(value => !UUID_LIKE.test(value));
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      message:
+        `cameraUuids contains ${invalid.length === 1 ? "a value that is not a uuid" : "values that are not uuids"}: ` +
+        `${invalid.map(value => `"${value}"`).join(", ")} — pass camera uuids, not camera names. ` +
+        `Resolve names to uuids with an entity lookup first.`,
+    };
+  }
+
+  return { ok: true, value: values };
+}

--- a/test/filtering-utils.test.ts
+++ b/test/filtering-utils.test.ts
@@ -504,11 +504,11 @@ describe("applyGroupBy", () => {
   });
 });
 
-describe("createFilteringProxy — missing structuredContent backstop", () => {
+describe("createFilteringProxy — tool result shape", () => {
   /**
-   * The failure this guards against is invisible at the handler level: the
-   * handler returns readable text and only the SDK's post-handler validation
-   * turns it into -32602. So drive it through the real SDK.
+   * These drive the REAL SDK on purpose. Whether a result survives
+   * `validateToolOutput` is invisible at the handler level — the handler returns
+   * readable text and only the SDK's post-handler validation can discard it.
    */
   async function callThroughProxy(result: unknown, opts: { outputSchema?: boolean } = {}) {
     const server = new McpServer({ name: "test", version: "0.0.0" });
@@ -536,15 +536,27 @@ describe("createFilteringProxy — missing structuredContent backstop", () => {
     }
   }
 
-  it("preserves the tool's message instead of letting the SDK emit -32602", async () => {
+  /**
+   * Pins the cost of NOT carrying structuredContent, so the next person to hit
+   * it recognises the symptom instead of rediscovering it in prod (it shipped
+   * there twice). The proxy used to paper over this by force-setting `isError`;
+   * that net was removed deliberately — it was unreachable (every tool with an
+   * outputSchema already returns structuredContent) and it could only ever flag
+   * the result as an error, which mislabels a legitimate text-only success like
+   * update-tool's `unsupportedResult`. The invariant is the tool's job:
+   * every return from a tool with an outputSchema carries structuredContent, or
+   * sets isError itself.
+   */
+  it("lets the SDK replace the message when a tool with an outputSchema omits structuredContent", async () => {
     const result = await callThroughProxy({
       content: [{ type: "text", text: "doorControllerUuid is required." }],
     });
 
     const text = (result.content as { text: string }[])[0].text;
-    expect(text).toBe("doorControllerUuid is required.");
-    expect(text).not.toContain("-32602");
     expect(result.isError).toBe(true);
+    expect(text).toContain("no structured content");
+    // The tool's own message is destroyed — this is the symptom to recognise.
+    expect(text).not.toContain("doorControllerUuid is required.");
   });
 
   it("leaves a well-formed result untouched", async () => {
@@ -563,8 +575,8 @@ describe("createFilteringProxy — missing structuredContent backstop", () => {
       { outputSchema: false }
     );
 
-    // No outputSchema means no validation to fail — flagging isError here would
-    // wrongly turn legitimate text results (the private MCP's pattern) into errors.
+    // No outputSchema means no validation to fail, so a text-only result is
+    // legitimate (the private MCP's pattern) and must not come back as an error.
     expect(result.isError).toBeFalsy();
   });
 });

--- a/test/tools/create-camera-policy-tool.test.ts
+++ b/test/tools/create-camera-policy-tool.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createTool } from "../../src/tools-console/create-camera-policy-tool.js";
+import { createFilteringProxy } from "../../src/filtering-utils.js";
+import * as network from "../../src/network/network.js";
+
+vi.mock("../../src/network/network.js", async importOriginal => {
+  const actual = await importOriginal<typeof network>();
+  return { ...actual, postApi: vi.fn() };
+});
+
+const SCHEDULE_UUID = "Wq1nR0kBS9y_2hZpVvGkAA";
+const CAMERA_UUID = "4Toqs6naTbulCRen-RxAPA";
+const CAMERA_UUID_2 = "9Kpqr2nbTculDRfn-SxBQB";
+const CREATED_POLICY_UUID = "pol1cyUu1dS9y2hZpVvGkAA";
+
+/** The proxy injects `includeFields` / `filterBy` / `groupBy` as nullable args. */
+function withNulledArgs(overrides: Record<string, unknown> = {}) {
+  return { includeFields: null, filterBy: null, groupBy: null, ...overrides };
+}
+
+async function callTool(args: Record<string, unknown>) {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  createTool(createFilteringProxy(server));
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  try {
+    return await client.callTool({ name: "create-camera-policy-tool", arguments: args });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+function textOf(result: Awaited<ReturnType<typeof callTool>>): string {
+  return (result.content as { text: string }[]).map(item => item.text).join("\n");
+}
+
+function routesCalled(): string[] {
+  return vi.mocked(network.postApi).mock.calls.map(call => call[0].route);
+}
+
+/** Happy path: create → schedules → cameras all succeed. */
+function mockAllPhasesOk() {
+  vi.mocked(network.postApi).mockImplementation((async ({ route }: { route: string }) => {
+    if (route === "/policy/createCameraPolicy") {
+      return { error: false, policyUuid: CREATED_POLICY_UUID };
+    }
+    return { error: false };
+  }) as never);
+}
+
+function fullRunArgs(overrides: Record<string, unknown> = {}) {
+  return withNulledArgs({
+    name: "After Hours Motion",
+    description: "Alert on people and vehicles after hours",
+    orgUuid: "org1234567890abcdefghi",
+    scheduleConfigs: JSON.stringify([
+      { scheduleUuid: SCHEDULE_UUID, activities: ["MOTION_HUMAN", "MOTION_CAR"] },
+    ]),
+    cameraUuids: `${CAMERA_UUID},${CAMERA_UUID_2}`,
+    ...overrides,
+  });
+}
+
+describe("create-camera-policy-tool — malformed scheduleConfigs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The prod failure (2026-08-04). The playbook tells the model to JSON-encode
+  // structured values into the form context; it then re-embedded the encoded
+  // string, so `activities` arrived as a STRING containing an array. The old code
+  // ran `config.activities.map` inside the JSON.parse try-block and reported
+  // "scheduleConfigs is not valid JSON (config.activities.map is not a
+  // function)" — which the model relayed as "an invalid configuration format".
+  it("accepts a double-encoded activities array instead of failing on it", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: SCHEDULE_UUID, activities: JSON.stringify(["MOTION_HUMAN"]) },
+        ]),
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(routesCalled()).toEqual([
+      "/policy/createCameraPolicy",
+      "/policy/updateCameraPolicy",
+      "/camera/updateDetailsBulkV2",
+    ]);
+    const scheduleCall = vi
+      .mocked(network.postApi)
+      .mock.calls.find(call => call[0].route === "/policy/updateCameraPolicy")!;
+    expect((scheduleCall[0].body as any).policy.scheduledTriggers).toEqual([
+      { scheduleUuid: SCHEDULE_UUID, triggerSet: [{ activity: "MOTION_HUMAN" }] },
+    ]);
+  });
+
+  it("accepts a comma-separated activities string", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: SCHEDULE_UUID, activities: "MOTION_HUMAN, MOTION_CAR" },
+        ]),
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    const scheduleCall = vi
+      .mocked(network.postApi)
+      .mock.calls.find(call => call[0].route === "/policy/updateCameraPolicy")!;
+    expect((scheduleCall[0].body as any).policy.scheduledTriggers[0].triggerSet).toEqual([
+      { activity: "MOTION_HUMAN" },
+      { activity: "MOTION_CAR" },
+    ]);
+  });
+
+  it("accepts a double-encoded scheduleConfigs string", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify(
+          JSON.stringify([{ scheduleUuid: SCHEDULE_UUID, activities: ["MOTION"] }])
+        ),
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(routesCalled()).toContain("/policy/createCameraPolicy");
+  });
+
+  it("accepts a single config object instead of a one-element array", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify({
+          scheduleUuid: SCHEDULE_UUID,
+          activities: ["MOTION_HUMAN"],
+        }),
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(routesCalled()).toContain("/policy/updateCameraPolicy");
+  });
+
+  it("accepts the API's own triggerSet shape", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: SCHEDULE_UUID, triggerSet: [{ activity: "MOTION_CAR" }] },
+        ]),
+      })
+    );
+
+    expect(result.isError).toBeFalsy();
+    const scheduleCall = vi
+      .mocked(network.postApi)
+      .mock.calls.find(call => call[0].route === "/policy/updateCameraPolicy")!;
+    expect((scheduleCall[0].body as any).policy.scheduledTriggers[0].triggerSet).toEqual([
+      { activity: "MOTION_CAR" },
+    ]);
+  });
+
+  it("rejects truly malformed JSON with the expected shape, before any mutation", async () => {
+    const result = await callTool(
+      fullRunArgs({ scheduleConfigs: '[{"scheduleUuid": "abc"' })
+    );
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("not valid JSON");
+    // The model needs the target shape, not just "invalid".
+    expect(text).toContain("scheduleUuid");
+    expect(text).toContain("activities");
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  it("names the offending field when activities is unreadable", async () => {
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([{ scheduleUuid: SCHEDULE_UUID, activities: 42 }]),
+      })
+    );
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("scheduleConfigs[0].activities");
+    expect(text).not.toContain("is not a function");
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  // The playbook used to offer LOITER_HUMAN / INACTIVITY_HUMAN, which are not in
+  // the API's ActivityEnum at all: create succeeded, updateCameraPolicy then
+  // rejected them, and the user was left with an empty orphan policy.
+  it("rejects an activity that is not an API constant before creating anything", async () => {
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: SCHEDULE_UUID, activities: ["LOITER_HUMAN"] },
+        ]),
+      })
+    );
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("LOITER_HUMAN");
+    expect(text).toContain("MOTION_HUMAN"); // lists what IS supported
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  it("rejects a display label rather than sending it to the API", async () => {
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: SCHEDULE_UUID, activities: ["Human Movement"] },
+        ]),
+      })
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("HUMAN_MOVEMENT");
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  it("rejects a schedule name where a uuid belongs", async () => {
+    const result = await callTool(
+      fullRunArgs({
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: "Business Hours", activities: ["MOTION_HUMAN"] },
+        ]),
+      })
+    );
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Business Hours");
+    expect(text).toContain("not a UUID");
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+});
+
+describe("create-camera-policy-tool — cameraUuids validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts a JSON-array-encoded cameraUuids", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      fullRunArgs({ cameraUuids: JSON.stringify([CAMERA_UUID, CAMERA_UUID_2]) })
+    );
+
+    expect(result.isError).toBeFalsy();
+    const cameraCall = vi
+      .mocked(network.postApi)
+      .mock.calls.find(call => call[0].route === "/camera/updateDetailsBulkV2")!;
+    expect((cameraCall[0].body as any).cameraBulkDetails.map((d: any) => d.uuid)).toEqual([
+      CAMERA_UUID,
+      CAMERA_UUID_2,
+    ]);
+  });
+
+  it("rejects camera names before creating the policy", async () => {
+    const result = await callTool(fullRunArgs({ cameraUuids: "Front Door, Back Lot" }));
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Front Door");
+    expect(text).toContain("not camera names");
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  // Previously: cameraList was empty, the `cameraList.length > 0` branch fell
+  // through with no return, and execution continued into policy creation —
+  // creating a second policy and reporting success.
+  it("does not fall through to policy creation when cameraUuids is unusable", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(
+      withNulledArgs({
+        name: "Should Not Be Created",
+        policyUuid: CREATED_POLICY_UUID,
+        cameraUuids: " , , ",
+      })
+    );
+
+    expect(result.isError).toBe(true);
+    expect(routesCalled()).not.toContain("/policy/createCameraPolicy");
+  });
+});
+
+describe("create-camera-policy-tool — error classification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("labels a pre-mutation validation failure RETRYABLE", async () => {
+    const result = await callTool(fullRunArgs({ scheduleConfigs: "not json at all" }));
+
+    const text = textOf(result);
+    expect(text).toContain("RETRYABLE");
+    expect(text).toContain("nothing was created or changed");
+    expect(text).not.toContain("PARTIAL STATE");
+    // Survives the caller's projection, so the model still sees the reason.
+    expect((result.structuredContent as { message?: string }).message).toContain("RETRYABLE");
+  });
+
+  it("labels a failed create RETRYABLE and surfaces the API's message", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({
+      error: true,
+      errorMsg: "a policy with that name already exists",
+    } as never);
+
+    const result = await callTool(fullRunArgs());
+
+    const text = textOf(result);
+    expect(text).toContain("RETRYABLE");
+    expect(text).toContain("a policy with that name already exists");
+    expect(routesCalled()).toEqual(["/policy/createCameraPolicy"]);
+  });
+
+  it("labels a schedule failure after a successful create PARTIAL STATE", async () => {
+    vi.mocked(network.postApi).mockImplementation((async ({ route }: { route: string }) => {
+      if (route === "/policy/createCameraPolicy") {
+        return { error: false, policyUuid: CREATED_POLICY_UUID };
+      }
+      return { error: true, errorMsg: "schedule not found" };
+    }) as never);
+
+    const result = await callTool(fullRunArgs());
+
+    const text = textOf(result);
+    expect(text).toContain("PARTIAL STATE");
+    expect(text).toContain("do NOT retry");
+    expect(text).toContain(CREATED_POLICY_UUID);
+    expect(text).toContain("schedule not found");
+    expect(text).not.toContain("RETRYABLE");
+    // Camera assignment must not run after the schedule step failed.
+    expect(routesCalled()).not.toContain("/camera/updateDetailsBulkV2");
+  });
+
+  it("labels a camera-assignment failure after create+schedules PARTIAL STATE", async () => {
+    vi.mocked(network.postApi).mockImplementation((async ({ route }: { route: string }) => {
+      if (route === "/policy/createCameraPolicy") {
+        return { error: false, policyUuid: CREATED_POLICY_UUID };
+      }
+      if (route === "/camera/updateDetailsBulkV2") {
+        return { error: true, errorMsg: "camera is offline" };
+      }
+      return { error: false };
+    }) as never);
+
+    const result = await callTool(fullRunArgs());
+
+    const text = textOf(result);
+    expect(text).toContain("PARTIAL STATE");
+    expect(text).toContain("camera is offline");
+  });
+
+  // The legacy per-step calls mutate an EXISTING policy, so retrying the failed
+  // step is safe — but re-creating the policy is not.
+  it("labels a legacy step failure retryable while forbidding a second policy", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({
+      error: true,
+      errorMsg: "schedule not found",
+    } as never);
+
+    const result = await callTool(
+      withNulledArgs({
+        policyUuid: CREATED_POLICY_UUID,
+        policyName: "After Hours Motion",
+        scheduleConfigs: JSON.stringify([
+          { scheduleUuid: SCHEDULE_UUID, activities: ["MOTION_HUMAN"] },
+        ]),
+      })
+    );
+
+    const text = textOf(result);
+    expect(text).toContain("RETRYABLE");
+    expect(text).toContain("already exists");
+    expect(text).toContain("do NOT create another one");
+  });
+});
+
+describe("create-camera-policy-tool — phase selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuses a full input set that also carries a policyUuid", async () => {
+    const result = await callTool(fullRunArgs({ policyUuid: CREATED_POLICY_UUID }));
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("RETRYABLE");
+    expect(text).toContain("Ambiguous");
+    // Neither creation nor a silent camera-assignment-only run.
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  // Only the literal "[]" used to be recognized as "no schedules yet" on a
+  // legacy step-1 call. Every other spelling of empty entered the schedule
+  // branch instead: "[ ]" hit `configs.length === 0` and fell through, and
+  // '"[]"' made `configs.length` read 2 off a string and then threw on
+  // `configs.map` — reported as "Error configuring schedules".
+  it.each(["[]", "[ ]", "[\n]", '"[]"'])(
+    "treats %s as no schedule configs and creates the policy",
+    async emptyConfigs => {
+      vi.mocked(network.postApi).mockResolvedValue({
+        error: false,
+        policyUuid: CREATED_POLICY_UUID,
+      } as never);
+
+      const result = await callTool(
+        withNulledArgs({ name: "New Policy", scheduleConfigs: emptyConfigs })
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(routesCalled()).toEqual(["/policy/createCameraPolicy"]);
+      expect(textOf(result)).toContain(CREATED_POLICY_UUID);
+    }
+  );
+
+  it("assigns cameras on the legacy step without claiming the whole setup finished", async () => {
+    vi.mocked(network.postApi).mockResolvedValue({ error: false } as never);
+
+    const result = await callTool(
+      withNulledArgs({
+        policyUuid: CREATED_POLICY_UUID,
+        policyName: "After Hours Motion",
+        cameraUuids: CAMERA_UUID,
+      })
+    );
+
+    const text = textOf(result);
+    expect(result.isError).toBeFalsy();
+    expect(text).toContain("assigned to 1 camera");
+    expect(text).not.toContain("completely finished");
+    expect(text).not.toContain("fully active");
+  });
+
+  it("refuses to assign cameras with an empty policyUuid", async () => {
+    const result = await callTool(withNulledArgs({ cameraUuids: CAMERA_UUID }));
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("policyUuid is empty");
+    expect(vi.mocked(network.postApi)).not.toHaveBeenCalled();
+  });
+
+  it("still runs the happy path end to end", async () => {
+    mockAllPhasesOk();
+
+    const result = await callTool(fullRunArgs());
+
+    expect(result.isError).toBeFalsy();
+    expect(routesCalled()).toEqual([
+      "/policy/createCameraPolicy",
+      "/policy/updateCameraPolicy",
+      "/camera/updateDetailsBulkV2",
+    ]);
+    const structured = result.structuredContent as { policyUuid?: string; message?: string };
+    expect(structured.policyUuid).toBe(CREATED_POLICY_UUID);
+    expect(structured.message).toContain("2 camera(s)");
+  });
+
+  it("surfaces an API warning on an otherwise successful run", async () => {
+    vi.mocked(network.postApi).mockImplementation((async ({ route }: { route: string }) => {
+      if (route === "/policy/createCameraPolicy") {
+        return {
+          error: false,
+          policyUuid: CREATED_POLICY_UUID,
+          warningMsg: "2 cameras do not support vehicle detection",
+        };
+      }
+      return { error: false };
+    }) as never);
+
+    const result = await callTool(fullRunArgs());
+
+    expect(result.isError).toBeFalsy();
+    expect(textOf(result)).toContain("2 cameras do not support vehicle detection");
+  });
+});


### PR DESCRIPTION
added updated openapi.json file, enforced better MCP responses (especially with bad arguments) with `create-camera-policy-tool`, and dropped a redundant function